### PR TITLE
Add domain types and conversation generator

### DIFF
--- a/src/engine/__tests__/conversation.test.ts
+++ b/src/engine/__tests__/conversation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { Effect } from 'effect'
+import { generateConversation } from '../conversation'
+import { DEFAULT_CONFIG } from '../types'
+import type { SimulationConfig, MessageType } from '../types'
+
+function run(config: SimulationConfig) {
+  return Effect.runSync(generateConversation(config))
+}
+
+describe('generateConversation', () => {
+  it('produces the expected number of messages with default config', () => {
+    const messages = run(DEFAULT_CONFIG)
+
+    // 1 system + 1 initial user
+    // 50 cycles, each: assistant + reasoning + tool_call + tool_result = 4 per cycle
+    // User messages: at cycles where (cycle > 1 && cycle % 10 === 1): cycles 11, 21, 31, 41 = 4 extra user messages
+    // Total: 2 + (50 * 4) + 4 = 206
+    expect(messages.length).toBe(206)
+  })
+
+  it('starts with system then user message', () => {
+    const messages = run(DEFAULT_CONFIG)
+    expect(messages[0].type).toBe('system')
+    expect(messages[1].type).toBe('user')
+  })
+
+  it('produces correct cycle ordering: assistant, reasoning, tool_call, tool_result', () => {
+    const messages = run(DEFAULT_CONFIG)
+    // First cycle starts at index 2
+    expect(messages[2].type).toBe('assistant')
+    expect(messages[3].type).toBe('reasoning')
+    expect(messages[4].type).toBe('tool_call')
+    expect(messages[5].type).toBe('tool_result')
+  })
+
+  it('assigns token sizes matching config values', () => {
+    const messages = run(DEFAULT_CONFIG)
+    expect(messages[0].tokens).toBe(DEFAULT_CONFIG.systemPromptSize)
+    expect(messages[1].tokens).toBe(DEFAULT_CONFIG.userMessageSize)
+    expect(messages[2].tokens).toBe(DEFAULT_CONFIG.assistantMessageSize)
+    expect(messages[3].tokens).toBe(DEFAULT_CONFIG.reasoningOutputSize)
+    expect(messages[4].tokens).toBe(DEFAULT_CONFIG.toolCallSize)
+    expect(messages[5].tokens).toBe(DEFAULT_CONFIG.toolResultSize)
+  })
+
+  it('inserts user messages at the configured frequency', () => {
+    const messages = run(DEFAULT_CONFIG)
+    const userMessages = messages.filter((m) => m.type === 'user')
+    // Initial user + one at cycles 11, 21, 31, 41 = 5 total
+    expect(userMessages.length).toBe(5)
+  })
+
+  it('skips reasoning messages when reasoningOutputSize is 0', () => {
+    const config: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      reasoningOutputSize: 0,
+    }
+    const messages = run(config)
+    const reasoning = messages.filter((m) => m.type === 'reasoning')
+    expect(reasoning.length).toBe(0)
+
+    // Without reasoning: 2 + (50 * 3) + 4 = 156
+    expect(messages.length).toBe(156)
+  })
+
+  it('assigns unique IDs to all messages', () => {
+    const messages = run(DEFAULT_CONFIG)
+    const ids = new Set(messages.map((m) => m.id))
+    expect(ids.size).toBe(messages.length)
+  })
+
+  it('all messages start with compacted: false', () => {
+    const messages = run(DEFAULT_CONFIG)
+    expect(messages.every((m) => m.compacted === false)).toBe(true)
+  })
+
+  it('handles 1 cycle with no reasoning', () => {
+    const config: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 1,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 10,
+    }
+    const messages = run(config)
+    // system + user + assistant + tool_call + tool_result = 5
+    expect(messages.length).toBe(5)
+    const types: MessageType[] = messages.map((m) => m.type)
+    expect(types).toEqual(['system', 'user', 'assistant', 'tool_call', 'tool_result'])
+  })
+
+  it('inserts user message every cycle when frequency is 1', () => {
+    const config: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 5,
+      userMessageFrequency: 1,
+    }
+    const messages = run(config)
+    const userMessages = messages.filter((m) => m.type === 'user')
+    // Initial user + every cycle where (cycle > 1 && cycle % 1 === 1) = cycles 2,3,4,5 = 4 extra
+    // Total: 1 + 4 = 5
+    expect(userMessages.length).toBe(5)
+  })
+})

--- a/src/engine/conversation.ts
+++ b/src/engine/conversation.ts
@@ -1,0 +1,53 @@
+import { Effect } from 'effect'
+import type { Message, MessageType, SimulationConfig } from './types'
+
+function makeMessage(index: number, type: MessageType, tokens: number): Message {
+  const id = `msg-${String(index).padStart(3, '0')}`
+  return { id, type, tokens, compacted: false }
+}
+
+/**
+ * Generate a conversation message sequence from simulation config.
+ *
+ * Message order per the spec:
+ *   [system] [user] [assistant] [reasoning?] [tool_call] [tool_result]
+ *                   [assistant] [reasoning?] [tool_call] [tool_result]
+ *                   ...
+ *   [user]  ← every userMessageFrequency cycles
+ *                   [assistant] [reasoning?] [tool_call] [tool_result]
+ *                   ...
+ */
+export const generateConversation = (
+  config: SimulationConfig,
+): Effect.Effect<readonly Message[]> =>
+  Effect.sync(() => {
+    const messages: Message[] = []
+    let idx = 0
+
+    const push = (type: MessageType, tokens: number) => {
+      messages.push(makeMessage(idx, type, tokens))
+      idx++
+    }
+
+    // Always starts with system + user
+    push('system', config.systemPromptSize)
+    push('user', config.userMessageSize)
+
+    for (let cycle = 1; cycle <= config.toolCallCycles; cycle++) {
+      // User message at configured frequency (cycle 1 doesn't get one — we already have the initial user message)
+      if (cycle > 1 && (cycle - 1) % config.userMessageFrequency === 0) {
+        push('user', config.userMessageSize)
+      }
+
+      push('assistant', config.assistantMessageSize)
+
+      if (config.reasoningOutputSize > 0) {
+        push('reasoning', config.reasoningOutputSize)
+      }
+
+      push('tool_call', config.toolCallSize)
+      push('tool_result', config.toolResultSize)
+    }
+
+    return messages
+  })

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,2 +1,114 @@
-// Domain types — to be implemented in Issue #3
-export {}
+export type MessageType =
+  | 'system'
+  | 'user'
+  | 'assistant'
+  | 'reasoning'
+  | 'tool_call'
+  | 'tool_result'
+  | 'summary'
+
+export interface Message {
+  readonly id: string
+  readonly type: MessageType
+  readonly tokens: number
+  readonly compacted: boolean
+  readonly compactedInto?: string
+}
+
+export interface SimulationConfig {
+  // Conversation shape
+  readonly toolCallCycles: number
+  readonly toolCallSize: number
+  readonly toolResultSize: number
+  readonly assistantMessageSize: number
+  readonly reasoningOutputSize: number
+  readonly userMessageFrequency: number
+  readonly userMessageSize: number
+  readonly systemPromptSize: number
+
+  // Context & compaction
+  readonly contextWindow: number
+  readonly compactionThreshold: number
+  readonly compressionRatio: number
+
+  // Pricing (per token, not per million)
+  readonly baseInputPrice: number
+  readonly outputPrice: number
+  readonly cacheWriteMultiplier: number
+  readonly cacheHitMultiplier: number
+  readonly minCacheableTokens: number
+  readonly compactionInputPrice: number
+  readonly compactionOutputPrice: number
+}
+
+export interface ContextState {
+  readonly messages: readonly Message[]
+  readonly totalTokens: number
+}
+
+export interface CacheState {
+  readonly cachedPrefixTokens: number
+  readonly cacheHitTokens: number
+  readonly cacheWriteTokens: number
+  readonly uncachedTokens: number
+  readonly hitRate: number
+}
+
+export interface StepCost {
+  readonly cachedInput: number
+  readonly cacheWrite: number
+  readonly uncachedInput: number
+  readonly output: number
+  readonly compactionInput: number
+  readonly compactionOutput: number
+  readonly total: number
+}
+
+export interface SimulationSnapshot {
+  readonly stepIndex: number
+  readonly message: Message
+  readonly conversation: readonly Message[]
+  readonly context: ContextState
+  readonly cache: CacheState
+  readonly cost: StepCost
+  readonly cumulativeCost: StepCost
+  readonly compactionEvent: boolean
+}
+
+export interface SimulationResult {
+  readonly config: SimulationConfig
+  readonly snapshots: readonly SimulationSnapshot[]
+  readonly summary: {
+    readonly totalCost: number
+    readonly totalTokensGenerated: number
+    readonly compactionEvents: number
+    readonly averageCacheHitRate: number
+    readonly peakContextSize: number
+  }
+}
+
+export const DEFAULT_CONFIG: SimulationConfig = {
+  // Conversation shape
+  toolCallCycles: 50,
+  toolCallSize: 200,
+  toolResultSize: 2_000,
+  assistantMessageSize: 300,
+  reasoningOutputSize: 500,
+  userMessageFrequency: 10,
+  userMessageSize: 200,
+  systemPromptSize: 4_000,
+
+  // Context & compaction
+  contextWindow: 200_000,
+  compactionThreshold: 0.85,
+  compressionRatio: 10,
+
+  // Pricing (per token)
+  baseInputPrice: 5.0 / 1_000_000,
+  outputPrice: 25.0 / 1_000_000,
+  cacheWriteMultiplier: 1.25,
+  cacheHitMultiplier: 0.10,
+  minCacheableTokens: 2_048,
+  compactionInputPrice: 0.80 / 1_000_000,
+  compactionOutputPrice: 4.0 / 1_000_000,
+}


### PR DESCRIPTION
## Summary

Closes #3

- Define all core simulation domain types in `src/engine/types.ts`: `MessageType`, `Message`, `SimulationConfig`, `ContextState`, `CacheState`, `StepCost`, `SimulationSnapshot`, `SimulationResult`, plus `DEFAULT_CONFIG` with spec defaults
- Implement Effect-based conversation generator in `src/engine/conversation.ts` that produces the correct message sequence (system → user → tool call cycles with reasoning toggle and periodic user messages)
- 10 unit tests covering message count, ordering, token sizes, user frequency, reasoning skip, unique IDs, and edge cases

## Test plan

- [x] All 12 tests pass (`npm test`)
- [x] TypeScript compiles cleanly (`tsc -b --noEmit`)
- [x] Verify types are compatible with downstream engine modules (issue #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)