### PR TITLE
Strategy 3: tool result compression

### DIFF
--- a/src/engine/__tests__/simulation.test.ts
+++ b/src/engine/__tests__/simulation.test.ts
@@ -184,6 +184,145 @@ describe('runSimulation', () => {
     )
   })
 
+  it('tool results are compressed when toolCompressionEnabled is true', () => {
+    const config: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 5,
+      toolResultSize: 2_000,
+      toolCompressionEnabled: true,
+      toolCompressionRatio: 5,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 100,
+      contextWindow: 200_000,
+    }
+    const result = run(config)
+    // Every tool_result in the conversation should be compressed
+    for (const snapshot of result.snapshots) {
+      if (snapshot.message.type === 'tool_result') {
+        expect(snapshot.message.tokens).toBe(Math.ceil(2_000 / 5))
+      }
+    }
+  })
+
+  it('tool results are untouched when toolCompressionEnabled is false', () => {
+    const config: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 5,
+      toolResultSize: 2_000,
+      toolCompressionEnabled: false,
+      toolCompressionRatio: 5,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 100,
+    }
+    const result = run(config)
+    for (const snapshot of result.snapshots) {
+      if (snapshot.message.type === 'tool_result') {
+        expect(snapshot.message.tokens).toBe(2_000)
+      }
+    }
+  })
+
+  it('compression ratio applies ceil division correctly', () => {
+    const config: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 3,
+      toolResultSize: 1_001, // 1001 / 3 = 333.67 → ceil = 334
+      toolCompressionEnabled: true,
+      toolCompressionRatio: 3,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 100,
+      contextWindow: 200_000,
+    }
+    const result = run(config)
+    for (const snapshot of result.snapshots) {
+      if (snapshot.message.type === 'tool_result') {
+        expect(snapshot.message.tokens).toBe(Math.ceil(1_001 / 3))
+      }
+    }
+  })
+
+  it('context grows slower with tool compression enabled', () => {
+    const baseConfig: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 10,
+      toolResultSize: 2_000,
+      toolCompressionEnabled: false,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 100,
+      contextWindow: 200_000,
+      compactionThreshold: 0.99, // effectively no compaction
+    }
+    const withCompression: SimulationConfig = {
+      ...baseConfig,
+      toolCompressionEnabled: true,
+      toolCompressionRatio: 5,
+    }
+
+    const resultWithout = run(baseConfig)
+    const resultWith = run(withCompression)
+
+    const peakWithout = resultWithout.summary.peakContextSize
+    const peakWith = resultWith.summary.peakContextSize
+    expect(peakWith).toBeLessThan(peakWithout)
+  })
+
+  it('fewer compaction events with tool compression enabled', () => {
+    const baseConfig: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 20,
+      toolCallSize: 200,
+      toolResultSize: 2_000,
+      assistantMessageSize: 300,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 100,
+      systemPromptSize: 4_000,
+      contextWindow: 10_000,
+      compactionThreshold: 0.8,
+      compressionRatio: 10,
+      toolCompressionEnabled: false,
+    }
+    const withCompression: SimulationConfig = {
+      ...baseConfig,
+      toolCompressionEnabled: true,
+      toolCompressionRatio: 5,
+    }
+
+    const resultWithout = run(baseConfig)
+    const resultWith = run(withCompression)
+
+    expect(resultWith.summary.compactionEvents).toBeLessThanOrEqual(
+      resultWithout.summary.compactionEvents,
+    )
+  })
+
+  it('tool compression works with incremental strategy', () => {
+    const config: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      selectedStrategy: 'incremental',
+      toolCallCycles: 20,
+      toolCallSize: 200,
+      toolResultSize: 2_000,
+      assistantMessageSize: 300,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 100,
+      systemPromptSize: 4_000,
+      incrementalInterval: 10_000,
+      summaryAccumulationThreshold: 50_000,
+      compressionRatio: 10,
+      toolCompressionEnabled: true,
+      toolCompressionRatio: 5,
+    }
+    const result = run(config)
+    // Should still run without error and produce snapshots
+    expect(result.snapshots.length).toBeGreaterThan(0)
+    // Tool results should be compressed
+    for (const snapshot of result.snapshots) {
+      if (snapshot.message.type === 'tool_result') {
+        expect(snapshot.message.tokens).toBe(Math.ceil(2_000 / 5))
+      }
+    }
+  })
+
   it('total tokens generated matches sum of all message tokens', () => {
     const config: SimulationConfig = {
       ...DEFAULT_CONFIG,

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -59,7 +59,15 @@ export const runSimulation = (
       const strategy = getStrategy(config.selectedStrategy)
 
       for (let i = 0; i < allMessages.length; i++) {
-        const message = allMessages[i]
+        // Apply tool result compression at ingestion (zero LLM cost)
+        const raw = allMessages[i]
+        const message =
+          config.toolCompressionEnabled && raw.type === 'tool_result'
+            ? {
+                ...raw,
+                tokens: Math.ceil(raw.tokens / config.toolCompressionRatio),
+              }
+            : raw
         conversation.push(message)
         totalTokensGenerated += message.tokens
 


### PR DESCRIPTION
Closes #20

## Summary

- Apply tool result compression at ingestion in `simulation.ts` — when `toolCompressionEnabled` is true, `tool_result` tokens are reduced via `ceil(tokens / toolCompressionRatio)` before entering the conversation
- Zero LLM cost (modelled as non-LLM truncation/extraction)
- Effect: slower context growth → delayed compaction → better cache stability
- UI controls already existed from #21

## Test plan

- [x] Tool results compressed when enabled, untouched when disabled
- [x] Compression ratio applies ceil division correctly
- [x] Context grows slower with compression enabled
- [x] Fewer compaction events compared to no compression
- [x] Works correctly combined with both Strategy 1 and Strategy 2
- [x] All 56 tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)