### PR TITLE
Refactor simulation loop into step pipeline

### DIFF
--- a/src/engine/__tests__/pipeline.test.ts
+++ b/src/engine/__tests__/pipeline.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from 'vitest'
+import type { StepState } from '../simulation'
+import {
+  ingestMessage,
+  buildContext,
+  evaluateCompaction,
+  updateExternalStore,
+  calculateCache,
+  rollRetrieval,
+  calculateCost,
+  buildSnapshot,
+} from '../simulation'
+import type { Message, SimulationConfig } from '../types'
+import { DEFAULT_CONFIG, EMPTY_EXTERNAL_STORE } from '../types'
+import { ZERO_COST } from '../cost'
+import { ZERO_CACHE } from '../cache'
+
+function makeState(overrides?: Partial<StepState>): StepState {
+  return {
+    conversation: [],
+    context: { messages: [], totalTokens: 0 },
+    previousContext: null,
+    externalStore: EMPTY_EXTERNAL_STORE,
+    compressedTokens: 0,
+    summaryCounter: 0,
+    cumulativeCost: ZERO_COST,
+    peakContextSize: 0,
+    compactionEvent: false,
+    tokensCompacted: 0,
+    summaryTokens: 0,
+    cache: ZERO_CACHE,
+    stepCost: ZERO_COST,
+    ...overrides,
+  }
+}
+
+function makeMessage(
+  id: string,
+  type: Message['type'],
+  tokens: number,
+): Message {
+  return { id, type, tokens, compacted: false }
+}
+
+const config: SimulationConfig = {
+  ...DEFAULT_CONFIG,
+  toolCompressionEnabled: false,
+}
+
+describe('pipeline stages', () => {
+  describe('ingestMessage', () => {
+    it('adds the message to conversation', () => {
+      const state = makeState()
+      const msg = makeMessage('m1', 'user', 200)
+      const next = ingestMessage(state, msg, config)
+      expect(next.conversation).toHaveLength(1)
+      expect(next.conversation[0].id).toBe('m1')
+    })
+
+    it('applies tool compression when enabled', () => {
+      const compConfig = { ...config, toolCompressionEnabled: true, toolCompressionRatio: 5 }
+      const state = makeState()
+      const msg = makeMessage('m1', 'tool_result', 1000)
+      const next = ingestMessage(state, msg, compConfig)
+      expect(next.conversation[0].tokens).toBe(200)
+    })
+
+    it('does not mutate original state', () => {
+      const state = makeState()
+      const msg = makeMessage('m1', 'user', 200)
+      const conversationBefore = state.conversation
+      ingestMessage(state, msg, config)
+      expect(state.conversation).toBe(conversationBefore)
+      expect(state.conversation).toHaveLength(0)
+    })
+
+    it('resets per-step transient fields', () => {
+      const state = makeState({
+        compactionEvent: true,
+        tokensCompacted: 500,
+        summaryTokens: 50,
+      })
+      const msg = makeMessage('m1', 'user', 200)
+      const next = ingestMessage(state, msg, config)
+      expect(next.compactionEvent).toBe(false)
+      expect(next.tokensCompacted).toBe(0)
+      expect(next.summaryTokens).toBe(0)
+    })
+  })
+
+  describe('buildContext', () => {
+    it('filters out compacted messages', () => {
+      const state = makeState({
+        conversation: [
+          makeMessage('m1', 'system', 1000),
+          { ...makeMessage('m2', 'user', 200), compacted: true, compactedInto: 's1' },
+          makeMessage('s1', 'summary', 50),
+          makeMessage('m3', 'assistant', 300),
+        ],
+      })
+      const next = buildContext(state)
+      expect(next.context.messages).toHaveLength(3)
+      expect(next.context.messages.map((m) => m.id)).toEqual(['m1', 's1', 'm3'])
+      expect(next.context.totalTokens).toBe(1350)
+    })
+
+    it('does not mutate original state', () => {
+      const state = makeState({
+        conversation: [makeMessage('m1', 'system', 1000)],
+      })
+      const contextBefore = state.context
+      buildContext(state)
+      expect(state.context).toBe(contextBefore)
+    })
+  })
+
+  describe('evaluateCompaction', () => {
+    it('returns state unchanged when compaction does not fire', () => {
+      const state = makeState({
+        conversation: [
+          makeMessage('m1', 'system', 1000),
+          makeMessage('m2', 'user', 200),
+        ],
+        context: {
+          messages: [
+            makeMessage('m1', 'system', 1000),
+            makeMessage('m2', 'user', 200),
+          ],
+          totalTokens: 1200,
+        },
+      })
+      const bigWindowConfig = { ...config, contextWindow: 200_000, compactionThreshold: 0.85 }
+      const next = evaluateCompaction(state, bigWindowConfig)
+      expect(next.compactionEvent).toBe(false)
+      expect(next.conversation).toBe(state.conversation)
+    })
+
+    it('fires compaction and produces new state when threshold exceeded', () => {
+      const messages = [
+        makeMessage('m1', 'system', 1000),
+        makeMessage('m2', 'user', 5000),
+        makeMessage('m3', 'assistant', 5000),
+      ]
+      const state = makeState({
+        conversation: messages,
+        context: { messages, totalTokens: 11000 },
+      })
+      const smallConfig = {
+        ...config,
+        contextWindow: 10_000,
+        compactionThreshold: 0.8,
+        compressionRatio: 10,
+      }
+      const next = evaluateCompaction(state, smallConfig)
+      expect(next.compactionEvent).toBe(true)
+      expect(next.tokensCompacted).toBeGreaterThan(0)
+      expect(next.summaryCounter).toBeGreaterThan(0)
+    })
+
+    it('does not mutate original state', () => {
+      const messages = [
+        makeMessage('m1', 'system', 1000),
+        makeMessage('m2', 'user', 5000),
+        makeMessage('m3', 'assistant', 5000),
+      ]
+      const state = makeState({
+        conversation: messages,
+        context: { messages, totalTokens: 11000 },
+      })
+      const smallConfig = {
+        ...config,
+        contextWindow: 10_000,
+        compactionThreshold: 0.8,
+        compressionRatio: 10,
+      }
+      const convBefore = state.conversation
+      const ctxBefore = state.context
+      evaluateCompaction(state, smallConfig)
+      expect(state.conversation).toBe(convBefore)
+      expect(state.context).toBe(ctxBefore)
+      expect(state.compactionEvent).toBe(false)
+      expect(state.summaryCounter).toBe(0)
+    })
+  })
+
+  describe('updateExternalStore', () => {
+    it('is a no-op (returns same state)', () => {
+      const state = makeState()
+      const next = updateExternalStore(state)
+      expect(next).toBe(state)
+    })
+  })
+
+  describe('calculateCache', () => {
+    it('returns state unchanged for non-LLM steps', () => {
+      const state = makeState({
+        context: {
+          messages: [makeMessage('m1', 'system', 1000)],
+          totalTokens: 1000,
+        },
+      })
+      const msg = makeMessage('m1', 'tool_result', 500)
+      const next = calculateCache(state, msg, config)
+      expect(next.cache).toBe(state.cache)
+      expect(next.previousContext).toBeNull()
+    })
+
+    it('calculates cache for LLM call steps', () => {
+      const messages = [
+        makeMessage('m1', 'system', 4000),
+        makeMessage('m2', 'user', 200),
+        makeMessage('m3', 'assistant', 300),
+      ]
+      const state = makeState({
+        context: { messages, totalTokens: 4500 },
+        previousContext: null,
+      })
+      const msg = makeMessage('m3', 'assistant', 300)
+      const next = calculateCache(state, msg, config)
+      // First LLM call — no previous, so cache writes expected
+      expect(next.cache.cacheWriteTokens).toBeGreaterThan(0)
+      expect(next.previousContext).toBe(state.context)
+    })
+  })
+
+  describe('rollRetrieval', () => {
+    it('is a no-op (returns same state)', () => {
+      const state = makeState()
+      const next = rollRetrieval(state)
+      expect(next).toBe(state)
+    })
+  })
+
+  describe('calculateCost', () => {
+    it('returns zero cost for non-LLM steps without compaction', () => {
+      const state = makeState({
+        context: {
+          messages: [makeMessage('m1', 'system', 1000)],
+          totalTokens: 1000,
+        },
+      })
+      const msg = makeMessage('m1', 'tool_result', 500)
+      const next = calculateCost(state, msg, config)
+      expect(next.stepCost.total).toBe(0)
+    })
+
+    it('calculates compaction cost even on non-LLM steps', () => {
+      const state = makeState({
+        compactionEvent: true,
+        tokensCompacted: 5000,
+        summaryTokens: 500,
+        context: {
+          messages: [makeMessage('m1', 'system', 1000)],
+          totalTokens: 1000,
+        },
+      })
+      const msg = makeMessage('m1', 'tool_result', 500)
+      const next = calculateCost(state, msg, config)
+      expect(next.stepCost.compactionInput).toBeGreaterThan(0)
+      expect(next.stepCost.compactionOutput).toBeGreaterThan(0)
+    })
+
+    it('updates peakContextSize', () => {
+      const state = makeState({
+        peakContextSize: 500,
+        context: {
+          messages: [makeMessage('m1', 'system', 1000)],
+          totalTokens: 1000,
+        },
+      })
+      const msg = makeMessage('m1', 'user', 200)
+      const next = calculateCost(state, msg, config)
+      expect(next.peakContextSize).toBe(1000)
+    })
+
+    it('does not lower peakContextSize', () => {
+      const state = makeState({
+        peakContextSize: 5000,
+        context: {
+          messages: [makeMessage('m1', 'system', 1000)],
+          totalTokens: 1000,
+        },
+      })
+      const msg = makeMessage('m1', 'user', 200)
+      const next = calculateCost(state, msg, config)
+      expect(next.peakContextSize).toBe(5000)
+    })
+  })
+
+  describe('buildSnapshot', () => {
+    it('creates a snapshot with correct fields', () => {
+      const state = makeState({
+        conversation: [makeMessage('m1', 'system', 1000)],
+        context: {
+          messages: [makeMessage('m1', 'system', 1000)],
+          totalTokens: 1000,
+        },
+        cumulativeCost: { ...ZERO_COST, total: 0.05 },
+        compactionEvent: true,
+      })
+      const msg = makeMessage('m1', 'system', 1000)
+      const snapshot = buildSnapshot(state, msg, 0)
+      expect(snapshot.stepIndex).toBe(0)
+      expect(snapshot.message.id).toBe('m1')
+      expect(snapshot.compactionEvent).toBe(true)
+      expect(snapshot.externalStore).toBe(EMPTY_EXTERNAL_STORE)
+      expect(snapshot.retrievalEvent).toBe(false)
+    })
+
+    it('creates a copy of conversation (not a reference)', () => {
+      const conv = [makeMessage('m1', 'system', 1000)]
+      const state = makeState({ conversation: conv })
+      const msg = makeMessage('m1', 'system', 1000)
+      const snapshot = buildSnapshot(state, msg, 0)
+      expect(snapshot.conversation).not.toBe(conv)
+      expect(snapshot.conversation).toEqual(conv)
+    })
+  })
+})

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -1,26 +1,45 @@
 import { Effect } from 'effect'
 import type {
+  CacheState,
   ContextState,
+  ExternalStore,
   Message,
   SimulationConfig,
   SimulationResult,
   SimulationSnapshot,
+  StepCost,
 } from './types'
+import { EMPTY_EXTERNAL_STORE } from './types'
 import { generateConversation } from './conversation'
 import { getStrategy } from './strategy'
 import { prefixCacheModel, ZERO_CACHE } from './cache'
 import { defaultCostCalculator, ZERO_COST, addCosts } from './cost'
 
-/**
- * Determine the output tokens for a step.
- *
- * An LLM call happens when the assistant produces output — on `assistant`
- * and `reasoning` steps. `tool_result`, `tool_call`, `user`, and `system`
- * messages just get appended to context without triggering an LLM call.
- *
- * Output tokens = the message's own token count (the assistant/reasoning
- * tokens that the model generated).
- */
+// ---------------------------------------------------------------------------
+// StepState — immutable state threaded through the pipeline
+// ---------------------------------------------------------------------------
+
+export interface StepState {
+  readonly conversation: readonly Message[]
+  readonly context: ContextState
+  readonly previousContext: ContextState | null
+  readonly externalStore: ExternalStore
+  readonly compressedTokens: number
+  readonly summaryCounter: number
+  readonly cumulativeCost: StepCost
+  readonly peakContextSize: number
+  // Per-step transient fields (reset each iteration)
+  readonly compactionEvent: boolean
+  readonly tokensCompacted: number
+  readonly summaryTokens: number
+  readonly cache: CacheState
+  readonly stepCost: StepCost
+}
+
+// ---------------------------------------------------------------------------
+// Helper — LLM call detection
+// ---------------------------------------------------------------------------
+
 function getOutputTokens(message: Message): number {
   if (message.type === 'assistant' || message.type === 'reasoning') {
     return message.tokens
@@ -28,19 +47,238 @@ function getOutputTokens(message: Message): number {
   return 0
 }
 
-/**
- * Returns true if this step triggers an LLM call.
- *
- * LLM calls happen on assistant messages. Reasoning messages are part of
- * the same LLM call as the preceding assistant message (extended thinking),
- * but for cost modelling we treat them as producing output tokens on the
- * same call context.
- *
- * tool_result messages just get appended — no LLM call.
- */
 function isLlmCallStep(message: Message): boolean {
   return message.type === 'assistant' || message.type === 'reasoning'
 }
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 1: ingestMessage
+// ---------------------------------------------------------------------------
+
+export function ingestMessage(
+  state: StepState,
+  rawMessage: Message,
+  config: SimulationConfig,
+): StepState {
+  const message =
+    config.toolCompressionEnabled && rawMessage.type === 'tool_result'
+      ? {
+          ...rawMessage,
+          tokens: Math.ceil(rawMessage.tokens / config.toolCompressionRatio),
+        }
+      : rawMessage
+
+  return {
+    ...state,
+    conversation: [...state.conversation, message],
+    // Reset per-step transient fields
+    compactionEvent: false,
+    tokensCompacted: 0,
+    summaryTokens: 0,
+    cache: ZERO_CACHE,
+    stepCost: ZERO_COST,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 2: buildContext
+// ---------------------------------------------------------------------------
+
+export function buildContext(state: StepState): StepState {
+  const active = state.conversation.filter((m) => !m.compacted)
+  const totalTokens = active.reduce((sum, m) => sum + m.tokens, 0)
+  return {
+    ...state,
+    context: { messages: active, totalTokens },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 3: evaluateCompaction
+// ---------------------------------------------------------------------------
+
+export function evaluateCompaction(
+  state: StepState,
+  config: SimulationConfig,
+): StepState {
+  const strategy = getStrategy(config.selectedStrategy)
+  const result = strategy.evaluate(state.context, config)
+
+  if (!result.shouldCompact || !result.newContext || !result.summaryMessage) {
+    return state
+  }
+
+  // Generate deterministic summary IDs for all new summaries
+  const newSummaries = result.newContext.messages.filter(
+    (m) =>
+      m.type === 'summary' &&
+      !state.context.messages.some((existing) => existing.id === m.id),
+  )
+  const summaryIdMap = new Map<string, string>()
+  let summaryCounter = state.summaryCounter
+  for (const s of newSummaries) {
+    summaryCounter++
+    summaryIdMap.set(s.id, `summary-${summaryCounter}`)
+  }
+
+  // The primary summary message (for cost and compactedInto tracking)
+  const primarySummaryId =
+    summaryIdMap.get(result.summaryMessage.id) ?? result.summaryMessage.id
+  const summaryMessage: Message = {
+    ...result.summaryMessage,
+    id: primarySummaryId,
+  }
+
+  // Calculate compaction metrics
+  const compactedIds = new Set(result.compactedMessageIds)
+  const tokensCompacted = state.context.messages
+    .filter((m) => compactedIds.has(m.id))
+    .reduce((sum, m) => sum + m.tokens, 0)
+
+  // Mark compacted messages in conversation
+  const updatedConversation = state.conversation.map((m) =>
+    compactedIds.has(m.id)
+      ? { ...m, compacted: true, compactedInto: summaryMessage.id }
+      : m,
+  )
+
+  // Add new summary messages to conversation
+  const conversationWithSummaries = [
+    ...updatedConversation,
+    ...newSummaries.map((s) => {
+      const remappedId = summaryIdMap.get(s.id) ?? s.id
+      return { ...s, id: remappedId }
+    }),
+  ]
+
+  // Build new context with remapped summary IDs
+  const newContext: ContextState = {
+    messages: result.newContext.messages.map((m) => {
+      const remappedId = summaryIdMap.get(m.id)
+      return remappedId ? { ...m, id: remappedId } : m
+    }),
+    totalTokens: result.newContext.totalTokens,
+  }
+
+  return {
+    ...state,
+    conversation: conversationWithSummaries,
+    context: newContext,
+    summaryCounter,
+    compactionEvent: true,
+    tokensCompacted,
+    summaryTokens: summaryMessage.tokens,
+    compressedTokens: state.compressedTokens + tokensCompacted,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 4: updateExternalStore (no-op placeholder for V3)
+// ---------------------------------------------------------------------------
+
+export function updateExternalStore(state: StepState): StepState {
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 5: calculateCache
+// ---------------------------------------------------------------------------
+
+export function calculateCache(
+  state: StepState,
+  message: Message,
+  config: SimulationConfig,
+): StepState {
+  if (!isLlmCallStep(message)) {
+    return state
+  }
+
+  const cache = prefixCacheModel.calculate(
+    state.previousContext,
+    state.context,
+    config,
+  )
+
+  return {
+    ...state,
+    cache,
+    previousContext: state.context,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 6: rollRetrieval (no-op placeholder for V3)
+// ---------------------------------------------------------------------------
+
+export function rollRetrieval(state: StepState): StepState {
+  return state
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 7: calculateCost
+// ---------------------------------------------------------------------------
+
+export function calculateCost(
+  state: StepState,
+  message: Message,
+  config: SimulationConfig,
+): StepState {
+  let stepCost = ZERO_COST
+
+  if (isLlmCallStep(message)) {
+    const outputTokens = getOutputTokens(message)
+    stepCost = defaultCostCalculator.calculate(
+      state.cache,
+      outputTokens,
+      { fired: false, tokensCompacted: 0, summaryTokens: 0 },
+      config,
+    )
+  }
+
+  // Compaction cost is independent of LLM call — always add when compaction fires
+  if (state.compactionEvent) {
+    const compactionCost = defaultCostCalculator.calculateCompactionCost(
+      state.tokensCompacted,
+      state.summaryTokens,
+      config,
+    )
+    stepCost = addCosts(stepCost, compactionCost)
+  }
+
+  return {
+    ...state,
+    stepCost,
+    cumulativeCost: addCosts(state.cumulativeCost, stepCost),
+    peakContextSize: Math.max(state.peakContextSize, state.context.totalTokens),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 8: buildSnapshot
+// ---------------------------------------------------------------------------
+
+export function buildSnapshot(
+  state: StepState,
+  message: Message,
+  stepIndex: number,
+): SimulationSnapshot {
+  return {
+    stepIndex,
+    message,
+    conversation: [...state.conversation],
+    context: state.context,
+    cache: state.cache,
+    cost: state.stepCost,
+    cumulativeCost: { ...state.cumulativeCost },
+    compactionEvent: state.compactionEvent,
+    externalStore: state.externalStore,
+    retrievalEvent: false,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main simulation runner
+// ---------------------------------------------------------------------------
 
 export const runSimulation = (
   config: SimulationConfig,
@@ -48,147 +286,41 @@ export const runSimulation = (
   Effect.flatMap(generateConversation(config), (allMessages) =>
     Effect.sync(() => {
       const snapshots: SimulationSnapshot[] = []
-      const conversation: Message[] = []
-      let previousContext: ContextState | null = null
-      let cumulativeCost = ZERO_COST
-      let compactionEvents = 0
-      let peakContextSize = 0
       let totalTokensGenerated = 0
-      let summaryCounter = 0
 
-      const strategy = getStrategy(config.selectedStrategy)
+      let state: StepState = {
+        conversation: [],
+        context: { messages: [], totalTokens: 0 },
+        previousContext: null,
+        externalStore: EMPTY_EXTERNAL_STORE,
+        compressedTokens: 0,
+        summaryCounter: 0,
+        cumulativeCost: ZERO_COST,
+        peakContextSize: 0,
+        // Per-step transient (reset in ingestMessage)
+        compactionEvent: false,
+        tokensCompacted: 0,
+        summaryTokens: 0,
+        cache: ZERO_CACHE,
+        stepCost: ZERO_COST,
+      }
 
       for (let i = 0; i < allMessages.length; i++) {
-        // Apply tool result compression at ingestion (zero LLM cost)
-        const raw = allMessages[i]
-        const message =
-          config.toolCompressionEnabled && raw.type === 'tool_result'
-            ? {
-                ...raw,
-                tokens: Math.ceil(raw.tokens / config.toolCompressionRatio),
-              }
-            : raw
-        conversation.push(message)
+        state = ingestMessage(state, allMessages[i], config)
+
+        // The processed message (with tool compression applied) is the last in conversation
+        const message = state.conversation[state.conversation.length - 1]
+
+        state = buildContext(state)
+        state = evaluateCompaction(state, config)
+        state = updateExternalStore(state)
+        state = calculateCache(state, message, config)
+        state = rollRetrieval(state)
+        state = calculateCost(state, message, config)
+
         totalTokensGenerated += message.tokens
 
-        // Build current context: all non-compacted messages
-        let context: ContextState = buildContext(conversation)
-
-        // Check strategy: does compaction fire?
-        let compactionEvent = false
-        let tokensCompacted = 0
-        let summaryTokens = 0
-        let summaryMessage: Message | undefined
-
-        const result = strategy.evaluate(context, config)
-        if (result.shouldCompact && result.newContext && result.summaryMessage) {
-          compactionEvent = true
-          compactionEvents++
-
-          // Generate deterministic summary IDs for all new summaries
-          // in the strategy result (replacing any temporary IDs)
-          const newSummaries = result.newContext.messages.filter(
-            (m) =>
-              m.type === 'summary' &&
-              !context.messages.some((existing) => existing.id === m.id),
-          )
-          const summaryIdMap = new Map<string, string>()
-          for (const s of newSummaries) {
-            summaryCounter++
-            summaryIdMap.set(s.id, `summary-${summaryCounter}`)
-          }
-
-          // The primary summary message (for cost and compactedInto tracking)
-          const primarySummaryId =
-            summaryIdMap.get(result.summaryMessage.id) ??
-            result.summaryMessage.id
-          summaryMessage = {
-            ...result.summaryMessage,
-            id: primarySummaryId,
-          }
-
-          // Calculate compaction cost: only the tokens that were actually compacted
-          const compactedIds = new Set(result.compactedMessageIds)
-          tokensCompacted = context.messages
-            .filter((m) => compactedIds.has(m.id))
-            .reduce((sum, m) => sum + m.tokens, 0)
-          summaryTokens = summaryMessage.tokens
-
-          // Mark compacted messages in conversation
-          for (let j = 0; j < conversation.length; j++) {
-            if (compactedIds.has(conversation[j].id)) {
-              conversation[j] = {
-                ...conversation[j],
-                compacted: true,
-                compactedInto: summaryMessage.id,
-              }
-            }
-          }
-
-          // Add new summary messages to conversation
-          for (const s of newSummaries) {
-            const remappedId = summaryIdMap.get(s.id) ?? s.id
-            conversation.push({ ...s, id: remappedId })
-          }
-
-          // Use the strategy's newContext directly, with remapped summary IDs
-          context = {
-            messages: result.newContext.messages.map((m) => {
-              const remappedId = summaryIdMap.get(m.id)
-              return remappedId ? { ...m, id: remappedId } : m
-            }),
-            totalTokens: result.newContext.totalTokens,
-          }
-        }
-
-        if (context.totalTokens > peakContextSize) {
-          peakContextSize = context.totalTokens
-        }
-
-        // Calculate cache and cost only on LLM call steps
-        let cache = ZERO_CACHE
-        let stepCost = ZERO_COST
-
-        if (isLlmCallStep(message)) {
-          cache = prefixCacheModel.calculate(
-            previousContext,
-            context,
-            config,
-          )
-
-          const outputTokens = getOutputTokens(message)
-          stepCost = defaultCostCalculator.calculate(
-            cache,
-            outputTokens,
-            { fired: false, tokensCompacted: 0, summaryTokens: 0 },
-            config,
-          )
-
-          previousContext = context
-        }
-
-        // Compaction cost is independent of LLM call — always add when compaction fires
-        if (compactionEvent) {
-          const compactionCost = defaultCostCalculator.calculateCompactionCost(
-            tokensCompacted,
-            summaryTokens,
-            config,
-          )
-          stepCost = addCosts(stepCost, compactionCost)
-        }
-
-        cumulativeCost = addCosts(cumulativeCost, stepCost)
-
-        snapshots.push({
-          stepIndex: i,
-          message,
-          conversation: [...conversation],
-          context,
-          cache,
-          cost: stepCost,
-          cumulativeCost: { ...cumulativeCost },
-          compactionEvent,
-        })
+        snapshots.push(buildSnapshot(state, message, i))
       }
 
       // Calculate average cache hit rate across LLM call steps
@@ -203,18 +335,12 @@ export const runSimulation = (
         config,
         snapshots,
         summary: {
-          totalCost: cumulativeCost.total,
+          totalCost: state.cumulativeCost.total,
           totalTokensGenerated,
-          compactionEvents,
+          compactionEvents: snapshots.filter((s) => s.compactionEvent).length,
           averageCacheHitRate,
-          peakContextSize,
+          peakContextSize: state.peakContextSize,
         },
       }
     }),
   )
-
-function buildContext(conversation: readonly Message[]): ContextState {
-  const active = conversation.filter((m) => !m.compacted)
-  const totalTokens = active.reduce((sum, m) => sum + m.tokens, 0)
-  return { messages: active, totalTokens }
-}

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -77,6 +77,23 @@ export interface StepCost {
   readonly total: number
 }
 
+export interface ExternalStoreEntry {
+  readonly id: string
+  readonly originalMessageIds: readonly string[]
+  readonly tokens: number
+  readonly level: number
+}
+
+export interface ExternalStore {
+  readonly entries: readonly ExternalStoreEntry[]
+  readonly totalTokens: number
+}
+
+export const EMPTY_EXTERNAL_STORE: ExternalStore = {
+  entries: [],
+  totalTokens: 0,
+}
+
 export interface SimulationSnapshot {
   readonly stepIndex: number
   readonly message: Message
@@ -86,6 +103,8 @@ export interface SimulationSnapshot {
   readonly cost: StepCost
   readonly cumulativeCost: StepCost
   readonly compactionEvent: boolean
+  readonly externalStore: ExternalStore
+  readonly retrievalEvent: boolean
 }
 
 export interface SimulationResult {


### PR DESCRIPTION
## Summary

- Refactors the procedural simulation loop into a pipeline of 8 pure transformation stages, each taking an immutable `StepState` and returning a new one
- Adds `ExternalStore`/`ExternalStoreEntry` types and `externalStore`/`retrievalEvent` fields to `SimulationSnapshot` as V3 placeholders
- Includes `updateExternalStore` and `rollRetrieval` no-op pipeline slots ready for Strategy 4x implementation
- 19 new pipeline stage tests verifying immutability, isolation, and correctness

Closes #26

## Test plan

- [x] All 59 existing tests pass unchanged (internal refactor only)
- [x] 19 new pipeline stage tests pass
- [x] Build succeeds
- [x] Lint passes (pre-existing warning only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)