### PR TITLE
External store infrastructure and retrieval probability model

### DIFF
--- a/src/engine/__tests__/pipeline.test.ts
+++ b/src/engine/__tests__/pipeline.test.ts
@@ -25,7 +25,9 @@ function makeState(overrides?: Partial<StepState>): StepState {
     summaryCounter: 0,
     cumulativeCost: ZERO_COST,
     peakContextSize: 0,
+    rng: () => 0.5,
     compactionEvent: false,
+    retrievalEvent: false,
     tokensCompacted: 0,
     summaryTokens: 0,
     cache: ZERO_CACHE,
@@ -184,10 +186,27 @@ describe('pipeline stages', () => {
   })
 
   describe('updateExternalStore', () => {
-    it('is a no-op (returns same state)', () => {
+    it('is a no-op when no compaction event', () => {
       const state = makeState()
       const next = updateExternalStore(state)
       expect(next).toBe(state)
+    })
+
+    it('stores compacted messages in external store when compaction fires', () => {
+      const state = makeState({
+        compactionEvent: true,
+        conversation: [
+          makeMessage('m1', 'system', 1000),
+          { ...makeMessage('m2', 'user', 5000), compacted: true, compactedInto: 'summary-1' },
+          { ...makeMessage('m3', 'assistant', 5000), compacted: true, compactedInto: 'summary-1' },
+          makeMessage('summary-1', 'summary', 500),
+        ],
+      })
+      const next = updateExternalStore(state)
+      expect(next.externalStore.entries).toHaveLength(1)
+      expect(next.externalStore.entries[0].originalMessageIds).toEqual(['m2', 'm3'])
+      expect(next.externalStore.entries[0].tokens).toBe(10000)
+      expect(next.externalStore.totalTokens).toBe(10000)
     })
   })
 
@@ -224,9 +243,51 @@ describe('pipeline stages', () => {
   })
 
   describe('rollRetrieval', () => {
-    it('is a no-op (returns same state)', () => {
-      const state = makeState()
-      const next = rollRetrieval(state)
+    it('is a no-op when external store is empty', () => {
+      const state = makeState({ compressedTokens: 50_000 })
+      const msg = makeMessage('m1', 'assistant', 300)
+      const next = rollRetrieval(state, msg, config)
+      expect(next).toBe(state)
+    })
+
+    it('is a no-op for non-LLM steps', () => {
+      const state = makeState({
+        externalStore: {
+          entries: [{ id: 'ext-1', originalMessageIds: ['m1'], tokens: 1000, level: 0 }],
+          totalTokens: 1000,
+        },
+        compressedTokens: 50_000,
+      })
+      const msg = makeMessage('m1', 'tool_result', 500)
+      const next = rollRetrieval(state, msg, config)
+      expect(next).toBe(state)
+    })
+
+    it('fires retrieval when roll is below probability', () => {
+      const state = makeState({
+        rng: () => 0.01, // always low
+        externalStore: {
+          entries: [{ id: 'ext-1', originalMessageIds: ['m1'], tokens: 1000, level: 0 }],
+          totalTokens: 1000,
+        },
+        compressedTokens: 100_000,
+      })
+      const msg = makeMessage('m1', 'assistant', 300)
+      const next = rollRetrieval(state, msg, config)
+      expect(next.retrievalEvent).toBe(true)
+    })
+
+    it('does not fire when roll exceeds probability', () => {
+      const state = makeState({
+        rng: () => 0.99, // always high
+        externalStore: {
+          entries: [{ id: 'ext-1', originalMessageIds: ['m1'], tokens: 1000, level: 0 }],
+          totalTokens: 1000,
+        },
+        compressedTokens: 100_000,
+      })
+      const msg = makeMessage('m1', 'assistant', 300)
+      const next = rollRetrieval(state, msg, config)
       expect(next).toBe(state)
     })
   })

--- a/src/engine/__tests__/retrieval.test.ts
+++ b/src/engine/__tests__/retrieval.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { createRng, retrievalProbability, retrievalCost } from '../retrieval'
+import { DEFAULT_CONFIG } from '../types'
+
+const config = DEFAULT_CONFIG
+
+describe('retrievalProbability', () => {
+  it('returns 0 when compressedTokens is 0', () => {
+    expect(retrievalProbability(0, config)).toBe(0)
+  })
+
+  it('returns pRetrieveMax when compressedTokens equals cap', () => {
+    expect(retrievalProbability(100_000, config)).toBeCloseTo(0.20, 6)
+  })
+
+  it('returns pRetrieveMax when compressedTokens exceeds cap', () => {
+    expect(retrievalProbability(200_000, config)).toBeCloseTo(0.20, 6)
+  })
+
+  it('scales linearly between 0 and cap', () => {
+    const half = retrievalProbability(50_000, config)
+    expect(half).toBeCloseTo(0.10, 6)
+
+    const quarter = retrievalProbability(25_000, config)
+    expect(quarter).toBeCloseTo(0.05, 6)
+  })
+
+  it('returns 0 when pRetrieveMax is 0', () => {
+    const zeroConfig = { ...config, pRetrieveMax: 0 }
+    expect(retrievalProbability(100_000, zeroConfig)).toBe(0)
+  })
+
+  it('returns 0 when compressedTokensCap is 0', () => {
+    const zeroCapConfig = { ...config, compressedTokensCap: 0 }
+    expect(retrievalProbability(50_000, zeroCapConfig)).toBe(0)
+  })
+})
+
+describe('retrievalCost', () => {
+  it('calculates input cost from retrievalQueryTokens', () => {
+    const cost = retrievalCost(config)
+    // 500 * (5/1M) = 0.0025
+    expect(cost.retrievalInput).toBeCloseTo(0.0025, 6)
+  })
+
+  it('calculates output cost from retrievalResponseTokens', () => {
+    const cost = retrievalCost(config)
+    // 300 * (25/1M) = 0.0075
+    expect(cost.retrievalOutput).toBeCloseTo(0.0075, 6)
+  })
+
+  it('total equals input + output', () => {
+    const cost = retrievalCost(config)
+    expect(cost.total).toBeCloseTo(cost.retrievalInput + cost.retrievalOutput, 10)
+  })
+
+  it('other cost fields are zero', () => {
+    const cost = retrievalCost(config)
+    expect(cost.cachedInput).toBe(0)
+    expect(cost.cacheWrite).toBe(0)
+    expect(cost.uncachedInput).toBe(0)
+    expect(cost.output).toBe(0)
+    expect(cost.compactionInput).toBe(0)
+    expect(cost.compactionOutput).toBe(0)
+  })
+})
+
+describe('createRng (seeded PRNG)', () => {
+  it('produces deterministic results for the same seed', () => {
+    const rng1 = createRng(42)
+    const rng2 = createRng(42)
+    const values1 = Array.from({ length: 10 }, () => rng1())
+    const values2 = Array.from({ length: 10 }, () => rng2())
+    expect(values1).toEqual(values2)
+  })
+
+  it('produces different results for different seeds', () => {
+    const rng1 = createRng(42)
+    const rng2 = createRng(99)
+    const values1 = Array.from({ length: 5 }, () => rng1())
+    const values2 = Array.from({ length: 5 }, () => rng2())
+    expect(values1).not.toEqual(values2)
+  })
+
+  it('produces values in [0, 1)', () => {
+    const rng = createRng(123)
+    for (let i = 0; i < 1000; i++) {
+      const v = rng()
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(1)
+    }
+  })
+})

--- a/src/engine/cost.ts
+++ b/src/engine/cost.ts
@@ -24,6 +24,8 @@ export const ZERO_COST: StepCost = {
   output: 0,
   compactionInput: 0,
   compactionOutput: 0,
+  retrievalInput: 0,
+  retrievalOutput: 0,
   total: 0,
 }
 
@@ -69,6 +71,8 @@ export const defaultCostCalculator: CostCalculator = {
       output,
       compactionInput,
       compactionOutput,
+      retrievalInput: 0,
+      retrievalOutput: 0,
       total,
     }
   },
@@ -93,6 +97,8 @@ export function addCosts(a: StepCost, b: StepCost): StepCost {
     output: a.output + b.output,
     compactionInput: a.compactionInput + b.compactionInput,
     compactionOutput: a.compactionOutput + b.compactionOutput,
+    retrievalInput: a.retrievalInput + b.retrievalInput,
+    retrievalOutput: a.retrievalOutput + b.retrievalOutput,
     total: a.total + b.total,
   }
 }

--- a/src/engine/retrieval.ts
+++ b/src/engine/retrieval.ts
@@ -1,0 +1,63 @@
+import type { SimulationConfig, StepCost } from './types'
+import { ZERO_COST } from './cost'
+
+// ---------------------------------------------------------------------------
+// Seeded PRNG — mulberry32
+// ---------------------------------------------------------------------------
+
+export type Rng = () => number
+
+/**
+ * Create a seeded PRNG (mulberry32). Returns a function that produces
+ * deterministic floats in [0, 1) on each call.
+ */
+export function createRng(seed: number): Rng {
+  let s = seed | 0
+  return () => {
+    s = (s + 0x6d2b79f5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval probability model
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate the probability of a retrieval event this step.
+ *
+ * Linear from 0% to pRetrieveMax as compressedTokens goes from 0 to
+ * compressedTokensCap, then flat at pRetrieveMax.
+ */
+export function retrievalProbability(
+  compressedTokens: number,
+  config: SimulationConfig,
+): number {
+  if (config.compressedTokensCap <= 0 || config.pRetrieveMax <= 0) return 0
+  const ratio = Math.min(compressedTokens / config.compressedTokensCap, 1.0)
+  return ratio * config.pRetrieveMax
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval cost calculator
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate the cost of a single retrieval event.
+ *
+ * The retrieval is modelled as an additional LLM call:
+ * - Input: retrievalQueryTokens at base input price
+ * - Output: retrievalResponseTokens at output price
+ */
+export function retrievalCost(config: SimulationConfig): StepCost {
+  const retrievalInput = config.retrievalQueryTokens * config.baseInputPrice
+  const retrievalOutput = config.retrievalResponseTokens * config.outputPrice
+  return {
+    ...ZERO_COST,
+    retrievalInput,
+    retrievalOutput,
+    total: retrievalInput + retrievalOutput,
+  }
+}

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -3,6 +3,7 @@ import type {
   CacheState,
   ContextState,
   ExternalStore,
+  ExternalStoreEntry,
   Message,
   SimulationConfig,
   SimulationResult,
@@ -14,6 +15,12 @@ import { generateConversation } from './conversation'
 import { getStrategy } from './strategy'
 import { prefixCacheModel, ZERO_CACHE } from './cache'
 import { defaultCostCalculator, ZERO_COST, addCosts } from './cost'
+import {
+  createRng,
+  retrievalProbability,
+  retrievalCost,
+  type Rng,
+} from './retrieval'
 
 // ---------------------------------------------------------------------------
 // StepState — immutable state threaded through the pipeline
@@ -28,8 +35,10 @@ export interface StepState {
   readonly summaryCounter: number
   readonly cumulativeCost: StepCost
   readonly peakContextSize: number
+  readonly rng: Rng
   // Per-step transient fields (reset each iteration)
   readonly compactionEvent: boolean
+  readonly retrievalEvent: boolean
   readonly tokensCompacted: number
   readonly summaryTokens: number
   readonly cache: CacheState
@@ -73,6 +82,7 @@ export function ingestMessage(
     conversation: [...state.conversation, message],
     // Reset per-step transient fields
     compactionEvent: false,
+    retrievalEvent: false,
     tokensCompacted: 0,
     summaryTokens: 0,
     cache: ZERO_CACHE,
@@ -173,11 +183,40 @@ export function evaluateCompaction(
 }
 
 // ---------------------------------------------------------------------------
-// Pipeline stage 4: updateExternalStore (no-op placeholder for V3)
+// Pipeline stage 4: updateExternalStore
 // ---------------------------------------------------------------------------
 
+/**
+ * When compaction fires, store the compacted messages in the external store.
+ * This is a no-op when no compaction event occurred this step.
+ */
 export function updateExternalStore(state: StepState): StepState {
-  return state
+  if (!state.compactionEvent) return state
+
+  // Find messages that were compacted this step (compacted but not already in store)
+  const existingIds = new Set(
+    state.externalStore.entries.flatMap((e) => e.originalMessageIds),
+  )
+  const newlyCompacted = state.conversation.filter(
+    (m) => m.compacted && !existingIds.has(m.id),
+  )
+
+  if (newlyCompacted.length === 0) return state
+
+  const newEntry: ExternalStoreEntry = {
+    id: `ext-${state.externalStore.entries.length + 1}`,
+    originalMessageIds: newlyCompacted.map((m) => m.id),
+    tokens: newlyCompacted.reduce((sum, m) => sum + m.tokens, 0),
+    level: 0,
+  }
+
+  return {
+    ...state,
+    externalStore: {
+      entries: [...state.externalStore.entries, newEntry],
+      totalTokens: state.externalStore.totalTokens + newEntry.tokens,
+    },
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -207,11 +246,29 @@ export function calculateCache(
 }
 
 // ---------------------------------------------------------------------------
-// Pipeline stage 6: rollRetrieval (no-op placeholder for V3)
+// Pipeline stage 6: rollRetrieval
 // ---------------------------------------------------------------------------
 
-export function rollRetrieval(state: StepState): StepState {
-  return state
+/**
+ * Roll the dice for a retrieval event. If the external store is empty or the
+ * roll fails, this is a no-op. When retrieval fires, the cost is added to
+ * the step cost in calculateCost.
+ */
+export function rollRetrieval(
+  state: StepState,
+  message: Message,
+  config: SimulationConfig,
+): StepState {
+  // Only roll on LLM call steps when there's something in the store
+  if (!isLlmCallStep(message) || state.externalStore.entries.length === 0) {
+    return state
+  }
+
+  const p = retrievalProbability(state.compressedTokens, config)
+  const roll = state.rng()
+  if (roll >= p) return state
+
+  return { ...state, retrievalEvent: true }
 }
 
 // ---------------------------------------------------------------------------
@@ -245,6 +302,11 @@ export function calculateCost(
     stepCost = addCosts(stepCost, compactionCost)
   }
 
+  // Retrieval cost when a retrieval event fired
+  if (state.retrievalEvent) {
+    stepCost = addCosts(stepCost, retrievalCost(config))
+  }
+
   return {
     ...state,
     stepCost,
@@ -272,7 +334,7 @@ export function buildSnapshot(
     cumulativeCost: { ...state.cumulativeCost },
     compactionEvent: state.compactionEvent,
     externalStore: state.externalStore,
-    retrievalEvent: false,
+    retrievalEvent: state.retrievalEvent,
   }
 }
 
@@ -297,8 +359,10 @@ export const runSimulation = (
         summaryCounter: 0,
         cumulativeCost: ZERO_COST,
         peakContextSize: 0,
+        rng: createRng(42),
         // Per-step transient (reset in ingestMessage)
         compactionEvent: false,
+        retrievalEvent: false,
         tokensCompacted: 0,
         summaryTokens: 0,
         cache: ZERO_CACHE,
@@ -315,7 +379,7 @@ export const runSimulation = (
         state = evaluateCompaction(state, config)
         state = updateExternalStore(state)
         state = calculateCache(state, message, config)
-        state = rollRetrieval(state)
+        state = rollRetrieval(state, message, config)
         state = calculateCost(state, message, config)
 
         totalTokensGenerated += message.tokens

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -44,6 +44,14 @@ export interface SimulationConfig {
   readonly toolCompressionEnabled: boolean
   readonly toolCompressionRatio: number
 
+  // Strategy 4 — Lossless with retrieval
+  readonly retrievalQueryTokens: number
+  readonly retrievalResponseTokens: number
+  readonly pRetrieveMax: number
+  readonly compressedTokensCap: number
+  readonly lcmGrepRatio: number
+  readonly lcmGrepResponseTokens: number
+
   // Pricing (per token, not per million)
   readonly baseInputPrice: number
   readonly outputPrice: number
@@ -74,6 +82,8 @@ export interface StepCost {
   readonly output: number
   readonly compactionInput: number
   readonly compactionOutput: number
+  readonly retrievalInput: number
+  readonly retrievalOutput: number
   readonly total: number
 }
 
@@ -154,4 +164,12 @@ export const DEFAULT_CONFIG: SimulationConfig = {
   // Strategy 3 — Tool result compression
   toolCompressionEnabled: false,
   toolCompressionRatio: 5,
+
+  // Strategy 4 — Lossless with retrieval
+  retrievalQueryTokens: 500,
+  retrievalResponseTokens: 300,
+  pRetrieveMax: 0.20,
+  compressedTokensCap: 100_000,
+  lcmGrepRatio: 0.70,
+  lcmGrepResponseTokens: 100,
 }


### PR DESCRIPTION
## Summary

- Add external store types, retrieval config params (`pRetrieveMax`, `compressedTokensCap`, `retrievalQueryTokens`, etc.), and `retrievalInput`/`retrievalOutput` to `StepCost`
- Create `retrieval.ts` with seeded PRNG (mulberry32), linear retrieval probability model, and retrieval cost calculator
- Implement `updateExternalStore` pipeline stage (stores compacted messages) and `rollRetrieval` (probabilistic retrieval on LLM steps)
- Add comprehensive tests for probability boundaries, PRNG determinism, cost calculation, and pipeline integration

Closes #27

## Test plan

- [x] Retrieval probability: boundary values (0, cap, beyond cap), linearity
- [x] Cost calculator: retrieval input/output amounts, total consistency
- [x] PRNG: same seed = same results, different seeds = different results, values in [0,1)
- [x] Pipeline: updateExternalStore no-op without compaction, stores on compaction
- [x] Pipeline: rollRetrieval no-op with empty store / non-LLM steps, fires/doesn't fire based on roll
- [x] Build passes, all 95 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)