### PR TITLE
Strategy 4c: tool-results-only lossless compaction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ function App() {
             {config.selectedStrategy === 'full-compaction' && 'Strategy 1 — Full compaction at threshold'}
             {config.selectedStrategy === 'incremental' && 'Strategy 2 — Incremental compaction at intervals'}
             {config.selectedStrategy === 'lossless-append' && 'Strategy 4a — Lossless append-only with external retrieval'}
+            {config.selectedStrategy === 'lossless-tool-results' && 'Strategy 4c — Tool-results-only lossless with external retrieval'}
             {config.toolCompressionEnabled && ' + tool result compression'}
           </p>
         </div>
@@ -80,7 +81,7 @@ function App() {
               label="Final Cost"
               value={formatCost(result.summary.totalCost)}
             />
-            {config.selectedStrategy === 'lossless-append' && (
+            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-tool-results') && (
               <>
                 <StatCard
                   label="External Store"
@@ -114,7 +115,7 @@ function App() {
         )}
 
         {/* External store visualisation (4x strategies only) */}
-        {currentSnapshot && config.selectedStrategy === 'lossless-append' && (
+        {currentSnapshot && (config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-tool-results') && (
           <ExternalStore
             snapshot={currentSnapshot}
             contextWindow={config.contextWindow}

--- a/src/components/controls/ParameterPanel.tsx
+++ b/src/components/controls/ParameterPanel.tsx
@@ -198,6 +198,7 @@ function StrategySelect({ value, onChange }: StrategySelectProps) {
           <SelectItem value="full-compaction" className="text-xs">1 — Full compaction</SelectItem>
           <SelectItem value="incremental" className="text-xs">2 — Incremental compaction</SelectItem>
           <SelectItem value="lossless-append" className="text-xs">4a — Lossless append-only</SelectItem>
+          <SelectItem value="lossless-tool-results" className="text-xs">4c — Tool-results-only lossless</SelectItem>
         </SelectContent>
       </Select>
     </div>
@@ -268,7 +269,7 @@ export function ParameterPanel({ config, onUpdate }: ParameterPanelProps) {
               onChange={(v) => onUpdate('selectedStrategy', v)}
             />
 
-            {(config.selectedStrategy === 'incremental' || config.selectedStrategy === 'lossless-append') && (
+            {(config.selectedStrategy === 'incremental' || config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-tool-results') && (
               <>
                 <SliderInput
                   label="Incremental interval (tokens)"
@@ -289,7 +290,7 @@ export function ParameterPanel({ config, onUpdate }: ParameterPanelProps) {
               </>
             )}
 
-            {config.selectedStrategy === 'lossless-append' && (
+            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-tool-results') && (
               <>
                 <NumberInput
                   label="pRetrieve max"

--- a/src/engine/__tests__/strategy.test.ts
+++ b/src/engine/__tests__/strategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { strategy1, strategy2, strategy4a, getStrategy } from '../strategy'
+import { strategy1, strategy2, strategy4a, strategy4c, getStrategy } from '../strategy'
 import type { ContextState, Message, SimulationConfig } from '../types'
 import { DEFAULT_CONFIG } from '../types'
 
@@ -405,6 +405,119 @@ describe('strategy4a', () => {
   })
 })
 
+describe('strategy4c', () => {
+  const config: SimulationConfig = {
+    ...DEFAULT_CONFIG,
+    contextWindow: 10_000,
+    compactionThreshold: 0.8,
+    incrementalInterval: 5_000,
+    summaryAccumulationThreshold: 10_000,
+    compressionRatio: 10,
+  }
+
+  it('does NOT compact when below thresholds', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 300),
+    ])
+    const result = strategy4c.evaluate(context, config)
+    expect(result.shouldCompact).toBe(false)
+    expect(result.externalStoreEntries).toBeUndefined()
+  })
+
+  it('only stores tool_result messages in external store', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 2_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 3_000),
+    ])
+    const result = strategy4c.evaluate(context, config)
+    expect(result.shouldCompact).toBe(true)
+    expect(result.externalStoreEntries).toBeDefined()
+    expect(result.externalStoreEntries!.length).toBe(1)
+
+    const entry = result.externalStoreEntries![0]
+    // Only tool_result messages in external store
+    expect(entry.originalMessageIds).toEqual(['tr1'])
+    expect(entry.tokens).toBe(3_000)
+  })
+
+  it('non-tool-result messages are compacted normally (lossy)', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 2_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 3_000),
+    ])
+    const result = strategy4c.evaluate(context, config)
+    // Compacted IDs include ALL non-system messages (same as strategy 2)
+    expect(result.compactedMessageIds).toContain('u1')
+    expect(result.compactedMessageIds).toContain('a1')
+    expect(result.compactedMessageIds).toContain('tc1')
+    expect(result.compactedMessageIds).toContain('tr1')
+  })
+
+  it('retrieval compressed tokens only counts tool_result tokens', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 2_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 3_000),
+    ])
+    const result = strategy4c.evaluate(context, config)
+    expect(result.retrievalCompressedTokens).toBe(3_000)
+  })
+
+  it('compaction context matches strategy2', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 2_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 3_000),
+    ])
+    const result4c = strategy4c.evaluate(context, config)
+    const result2 = strategy2.evaluate(context, config)
+    expect(result4c.newContext!.totalTokens).toBe(result2.newContext!.totalTokens)
+    expect(result4c.compactedMessageIds).toEqual(result2.compactedMessageIds)
+  })
+
+  it('stores multiple tool_results in a single external store entry', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 1_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 2_000),
+      makeMsg('a1', 'assistant', 300),
+      makeMsg('tc2', 'tool_call', 200),
+      makeMsg('tr2', 'tool_result', 2_500),
+    ])
+    // New content: 200 + 2000 + 300 + 200 + 2500 = 5200 > 5000
+    const result = strategy4c.evaluate(context, config)
+    expect(result.shouldCompact).toBe(true)
+    const entry = result.externalStoreEntries![0]
+    expect(entry.originalMessageIds).toEqual(['tr1', 'tr2'])
+    expect(entry.tokens).toBe(4_500)
+  })
+
+  it('returns retrievalCompressedTokens=0 when no tool_results are compacted', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 5_000),
+    ])
+    // New content: 200 + 5000 = 5200 > 5000, but no tool_results
+    const result = strategy4c.evaluate(context, config)
+    expect(result.shouldCompact).toBe(true)
+    expect(result.externalStoreEntries).toBeUndefined()
+    expect(result.retrievalCompressedTokens).toBe(0)
+  })
+})
+
 describe('getStrategy', () => {
   it('returns a valid strategy for full-compaction', () => {
     const strategy = getStrategy('full-compaction')
@@ -420,6 +533,12 @@ describe('getStrategy', () => {
 
   it('returns a valid strategy for lossless-append', () => {
     const strategy = getStrategy('lossless-append')
+    expect(strategy).toBeDefined()
+    expect(typeof strategy.evaluate).toBe('function')
+  })
+
+  it('returns a valid strategy for lossless-tool-results', () => {
+    const strategy = getStrategy('lossless-tool-results')
     expect(strategy).toBeDefined()
     expect(typeof strategy.evaluate).toBe('function')
   })

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -172,6 +172,9 @@ export function evaluateCompaction(
     totalTokens: result.newContext.totalTokens,
   }
 
+  const retrievalTokensAdded =
+    result.retrievalCompressedTokens ?? tokensCompacted
+
   return {
     ...state,
     conversation: conversationWithSummaries,
@@ -181,7 +184,7 @@ export function evaluateCompaction(
     tokensCompacted,
     summaryTokens: summaryMessage.tokens,
     pendingStoreEntries: result.externalStoreEntries ?? [],
-    compressedTokens: state.compressedTokens + tokensCompacted,
+    compressedTokens: state.compressedTokens + retrievalTokensAdded,
   }
 }
 

--- a/src/engine/strategy.ts
+++ b/src/engine/strategy.ts
@@ -13,6 +13,8 @@ export interface CompactionResult {
   readonly compactedMessageIds?: readonly string[]
   readonly summaryMessage?: Message
   readonly externalStoreEntries?: readonly ExternalStoreInput[]
+  /** When set, only this many tokens count toward retrieval probability (instead of all compacted tokens). */
+  readonly retrievalCompressedTokens?: number
 }
 
 export interface CompactionStrategy {
@@ -214,6 +216,53 @@ export const strategy4a: CompactionStrategy = {
 }
 
 /**
+ * Strategy 4c — Tool-results-only lossless compaction.
+ *
+ * Hybrid approach: general conversation is compacted using Strategy 2 logic
+ * (lossy, no external storage), but tool_result messages are stored externally
+ * before compaction. Retrieval probability is based only on the tool_result
+ * tokens that were compressed, not all compressed tokens.
+ */
+export const strategy4c: CompactionStrategy = {
+  evaluate(context, config) {
+    const result = strategy2.evaluate(context, config)
+    if (!result.shouldCompact || !result.compactedMessageIds) {
+      return result
+    }
+
+    // Find tool_result messages among those being compacted
+    const compactedIds = new Set(result.compactedMessageIds)
+    const compactedToolResults = context.messages.filter(
+      (m) => compactedIds.has(m.id) && m.type === 'tool_result',
+    )
+
+    // Only tool_result messages go to external store
+    if (compactedToolResults.length === 0) {
+      return { ...result, retrievalCompressedTokens: 0 }
+    }
+
+    const toolResultTokens = compactedToolResults.reduce(
+      (sum, m) => sum + m.tokens,
+      0,
+    )
+
+    const externalStoreEntries: ExternalStoreInput[] = [
+      {
+        originalMessageIds: compactedToolResults.map((m) => m.id),
+        tokens: toolResultTokens,
+        level: 0,
+      },
+    ]
+
+    return {
+      ...result,
+      externalStoreEntries,
+      retrievalCompressedTokens: toolResultTokens,
+    }
+  },
+}
+
+/**
  * Strategy registry — returns the compaction strategy for a given type.
  */
 export function getStrategy(type: StrategyType): CompactionStrategy {
@@ -224,5 +273,7 @@ export function getStrategy(type: StrategyType): CompactionStrategy {
       return strategy2
     case 'lossless-append':
       return strategy4a
+    case 'lossless-tool-results':
+      return strategy4c
   }
 }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -7,7 +7,7 @@ export type MessageType =
   | 'tool_result'
   | 'summary'
 
-export type StrategyType = 'full-compaction' | 'incremental' | 'lossless-append'
+export type StrategyType = 'full-compaction' | 'incremental' | 'lossless-append' | 'lossless-tool-results'
 
 export interface Message {
   readonly id: string


### PR DESCRIPTION
## Summary

- Implements Strategy 4c — hybrid compaction where general conversation is compacted lossy (Strategy 2 logic) but `tool_result` messages are stored externally for later retrieval
- Retrieval probability scales only with compressed tool_result tokens, not all compressed tokens
- Adds `retrievalCompressedTokens` to `CompactionResult` to support per-strategy retrieval token tracking

Closes #29

## Changes

**Engine:**
- `types.ts`: Added `'lossless-tool-results'` to `StrategyType`
- `strategy.ts`: Implemented `strategy4c`, added `retrievalCompressedTokens` to `CompactionResult`, updated `getStrategy` registry
- `simulation.ts`: `evaluateCompaction` uses `retrievalCompressedTokens` when present (falls back to full `tokensCompacted`)

**UI:**
- `ParameterPanel.tsx`: Added 4c to strategy selector, shows same conditional params as 4a (incremental interval, retrieval params)
- `App.tsx`: Added strategy description, External Store + Retrieval Events stat cards, and ExternalStore visualisation for 4c

**Tests:**
- 8 new tests covering: tool_result-only external storage, lossy compaction of non-tool messages, retrieval token tracking, multi-tool-result entries, zero tool_result edge case, context parity with Strategy 2

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new warnings)
- [x] `npm test` — 119 tests pass (8 new for strategy4c)
- [x] Manual: select 4c in UI, verify external store only shows tool result entries
- [x] Manual: toggle tool compression (Strategy 3) with 4c and verify interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)