### PR TITLE
Strategy 4d: LCM sub-agent retrieval

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ function App() {
             {config.selectedStrategy === 'lossless-append' && 'Strategy 4a — Lossless append-only with external retrieval'}
             {config.selectedStrategy === 'lossless-hierarchical' && 'Strategy 4b — Lossless hierarchical with levelled external retrieval'}
             {config.selectedStrategy === 'lossless-tool-results' && 'Strategy 4c — Tool-results-only lossless with external retrieval'}
+            {config.selectedStrategy === 'lcm-subagent' && 'Strategy 4d — LCM sub-agent retrieval (grep + expand)'}
             {config.toolCompressionEnabled && ' + tool result compression'}
           </p>
         </div>
@@ -82,7 +83,7 @@ function App() {
               label="Final Cost"
               value={formatCost(result.summary.totalCost)}
             />
-            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results') && (
+            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
               <>
                 <StatCard
                   label="External Store"
@@ -116,7 +117,7 @@ function App() {
         )}
 
         {/* External store visualisation (4x strategies only) */}
-        {currentSnapshot && (config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results') && (
+        {currentSnapshot && (config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
           <ExternalStore
             snapshot={currentSnapshot}
             contextWindow={config.contextWindow}

--- a/src/components/controls/ParameterPanel.tsx
+++ b/src/components/controls/ParameterPanel.tsx
@@ -200,6 +200,7 @@ function StrategySelect({ value, onChange }: StrategySelectProps) {
           <SelectItem value="lossless-append" className="text-xs">4a — Lossless append-only</SelectItem>
           <SelectItem value="lossless-hierarchical" className="text-xs">4b — Lossless hierarchical</SelectItem>
           <SelectItem value="lossless-tool-results" className="text-xs">4c — Tool-results-only lossless</SelectItem>
+          <SelectItem value="lcm-subagent" className="text-xs">4d — LCM sub-agent retrieval</SelectItem>
         </SelectContent>
       </Select>
     </div>
@@ -270,7 +271,7 @@ export function ParameterPanel({ config, onUpdate }: ParameterPanelProps) {
               onChange={(v) => onUpdate('selectedStrategy', v)}
             />
 
-            {(config.selectedStrategy === 'incremental' || config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results') && (
+            {(config.selectedStrategy === 'incremental' || config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
               <>
                 <SliderInput
                   label="Incremental interval (tokens)"
@@ -291,7 +292,7 @@ export function ParameterPanel({ config, onUpdate }: ParameterPanelProps) {
               </>
             )}
 
-            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results') && (
+            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
               <>
                 <NumberInput
                   label="pRetrieve max"
@@ -322,6 +323,26 @@ export function ParameterPanel({ config, onUpdate }: ParameterPanelProps) {
                   min={100}
                   max={5000}
                   onChange={(v) => onUpdate('retrievalResponseTokens', v)}
+                />
+              </>
+            )}
+
+            {config.selectedStrategy === 'lcm-subagent' && (
+              <>
+                <NumberInput
+                  label="LCM grep ratio"
+                  value={config.lcmGrepRatio}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  onChange={(v) => onUpdate('lcmGrepRatio', v)}
+                />
+                <NumberInput
+                  label="LCM grep response tokens"
+                  value={config.lcmGrepResponseTokens}
+                  min={10}
+                  max={2000}
+                  onChange={(v) => onUpdate('lcmGrepResponseTokens', v)}
                 />
               </>
             )}

--- a/src/engine/__tests__/retrieval.test.ts
+++ b/src/engine/__tests__/retrieval.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createRng, retrievalProbability, retrievalCost, averageStoreLevel } from '../retrieval'
+import { createRng, retrievalProbability, retrievalCost, lcmSubagentRetrievalCost, averageStoreLevel } from '../retrieval'
 import { DEFAULT_CONFIG } from '../types'
 
 const config = DEFAULT_CONFIG
@@ -78,6 +78,56 @@ describe('retrievalCost', () => {
     const baseCost = retrievalCost(config, 0)
     // multiplier = 1.5
     expect(cost.total).toBeCloseTo(baseCost.total * 1.5, 10)
+  })
+})
+
+describe('lcmSubagentRetrievalCost', () => {
+  it('blends grep and expand costs according to lcmGrepRatio', () => {
+    const cost = lcmSubagentRetrievalCost(config)
+
+    // grep cost: 500 * 5/1M + 100 * 25/1M = 0.0025 + 0.0025 = 0.005
+    const grepCost = 500 * (5 / 1_000_000) + 100 * (25 / 1_000_000)
+    // expand cost: (500 + 300) * 5/1M + 300 * 25/1M = 0.004 + 0.0075 = 0.0115
+    const expandCost = (500 + 300) * (5 / 1_000_000) + 300 * (25 / 1_000_000)
+    // blended: 0.70 * 0.005 + 0.30 * 0.0115 = 0.0035 + 0.00345 = 0.00695
+    const expected = 0.70 * grepCost + 0.30 * expandCost
+
+    expect(cost.total).toBeCloseTo(expected, 10)
+  })
+
+  it('total equals retrievalInput + retrievalOutput', () => {
+    const cost = lcmSubagentRetrievalCost(config)
+    expect(cost.total).toBeCloseTo(cost.retrievalInput + cost.retrievalOutput, 10)
+  })
+
+  it('other cost fields are zero', () => {
+    const cost = lcmSubagentRetrievalCost(config)
+    expect(cost.cachedInput).toBe(0)
+    expect(cost.cacheWrite).toBe(0)
+    expect(cost.uncachedInput).toBe(0)
+    expect(cost.output).toBe(0)
+    expect(cost.compactionInput).toBe(0)
+    expect(cost.compactionOutput).toBe(0)
+  })
+
+  it('with lcmGrepRatio=1.0, cost equals pure grep cost', () => {
+    const allGrepConfig = { ...config, lcmGrepRatio: 1.0 }
+    const cost = lcmSubagentRetrievalCost(allGrepConfig)
+
+    const grepInput = 500 * (5 / 1_000_000)
+    const grepOutput = 100 * (25 / 1_000_000)
+    expect(cost.retrievalInput).toBeCloseTo(grepInput, 10)
+    expect(cost.retrievalOutput).toBeCloseTo(grepOutput, 10)
+  })
+
+  it('with lcmGrepRatio=0.0, cost equals pure expand cost', () => {
+    const allExpandConfig = { ...config, lcmGrepRatio: 0.0 }
+    const cost = lcmSubagentRetrievalCost(allExpandConfig)
+
+    const expandInput = (500 + 300) * (5 / 1_000_000)
+    const expandOutput = 300 * (25 / 1_000_000)
+    expect(cost.retrievalInput).toBeCloseTo(expandInput, 10)
+    expect(cost.retrievalOutput).toBeCloseTo(expandOutput, 10)
   })
 })
 

--- a/src/engine/__tests__/strategy.test.ts
+++ b/src/engine/__tests__/strategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { strategy1, strategy2, strategy4a, strategy4b, strategy4c, getStrategy } from '../strategy'
+import { strategy1, strategy2, strategy4a, strategy4b, strategy4c, strategy4d, getStrategy } from '../strategy'
 import type { ContextState, Message, SimulationConfig } from '../types'
 import { DEFAULT_CONFIG } from '../types'
 
@@ -657,6 +657,126 @@ describe('strategy4c', () => {
   })
 })
 
+describe('strategy4d', () => {
+  const config: SimulationConfig = {
+    ...DEFAULT_CONFIG,
+    contextWindow: 10_000,
+    compactionThreshold: 0.8,
+    incrementalInterval: 5_000,
+    summaryAccumulationThreshold: 10_000,
+    compressionRatio: 10,
+  }
+
+  it('does NOT compact when below both thresholds', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 300),
+    ])
+    const result = strategy4d.evaluate(context, config)
+    expect(result.shouldCompact).toBe(false)
+    expect(result.externalStoreEntries).toBeUndefined()
+  })
+
+  it('compacts ALL non-system content into single summary', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 2_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 3_000),
+    ])
+    // New content: 5400 > 5000
+    const result = strategy4d.evaluate(context, config)
+    expect(result.shouldCompact).toBe(true)
+
+    // Context after: [system, summary]
+    expect(result.newContext!.messages.length).toBe(2)
+    expect(result.newContext!.messages[0].type).toBe('system')
+    expect(result.newContext!.messages[1].type).toBe('summary')
+
+    // Summary based on ALL non-system tokens (5400)
+    expect(result.summaryMessage!.tokens).toBe(Math.ceil(5_400 / 10))
+  })
+
+  it('compactedMessageIds includes all non-system messages', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('s0', 'summary', 540),
+      makeMsg('u2', 'user', 200),
+      makeMsg('a2', 'assistant', 5_000),
+    ])
+    const result = strategy4d.evaluate(context, config)
+    expect(result.shouldCompact).toBe(true)
+    expect(result.compactedMessageIds).toEqual(['s0', 'u2', 'a2'])
+  })
+
+  it('context is always [system] [single_summary] after compaction', () => {
+    // After first compaction with existing summary + new content
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('s0', 'summary', 540),
+      makeMsg('u2', 'user', 200),
+      makeMsg('a2', 'assistant', 2_000),
+      makeMsg('tc2', 'tool_call', 200),
+      makeMsg('tr2', 'tool_result', 3_000),
+    ])
+    const result = strategy4d.evaluate(context, config)
+    expect(result.shouldCompact).toBe(true)
+    expect(result.newContext!.messages.length).toBe(2)
+    expect(result.newContext!.messages[0].type).toBe('system')
+    expect(result.newContext!.messages[1].type).toBe('summary')
+  })
+
+  it('stores all compacted content in external store', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 2_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 3_000),
+    ])
+    const result = strategy4d.evaluate(context, config)
+    expect(result.externalStoreEntries).toBeDefined()
+    expect(result.externalStoreEntries!.length).toBe(1)
+
+    const entry = result.externalStoreEntries![0]
+    expect(entry.originalMessageIds).toEqual(['u1', 'a1', 'tc1', 'tr1'])
+    expect(entry.tokens).toBe(5_400)
+    expect(entry.level).toBe(0)
+  })
+
+  it('trigger is based on new content (after last summary), not total non-system', () => {
+    const context = makeContext([
+      makeMsg('sys', 'system', 4_000),
+      makeMsg('s0', 'summary', 540),
+      makeMsg('u2', 'user', 200),
+      makeMsg('a2', 'assistant', 300),
+    ])
+    // New content: 200 + 300 = 500 < 5000, total: 5040 < 8000
+    const result = strategy4d.evaluate(context, config)
+    expect(result.shouldCompact).toBe(false)
+  })
+
+  it('compacts when main threshold exceeded before incremental interval', () => {
+    const thresholdConfig: SimulationConfig = {
+      ...config,
+      incrementalInterval: 100_000,
+    }
+    const context = makeContext([
+      makeMsg('sys', 'system', 1_000),
+      makeMsg('u1', 'user', 200),
+      makeMsg('a1', 'assistant', 3_000),
+      makeMsg('tc1', 'tool_call', 200),
+      makeMsg('tr1', 'tool_result', 5_000),
+    ])
+    // 9400 > 8000 threshold
+    const result = strategy4d.evaluate(context, thresholdConfig)
+    expect(result.shouldCompact).toBe(true)
+    expect(result.compactedMessageIds).toEqual(['u1', 'a1', 'tc1', 'tr1'])
+  })
+})
+
 describe('getStrategy', () => {
   it('returns a valid strategy for full-compaction', () => {
     const strategy = getStrategy('full-compaction')
@@ -684,6 +804,12 @@ describe('getStrategy', () => {
 
   it('returns a valid strategy for lossless-tool-results', () => {
     const strategy = getStrategy('lossless-tool-results')
+    expect(strategy).toBeDefined()
+    expect(typeof strategy.evaluate).toBe('function')
+  })
+
+  it('returns a valid strategy for lcm-subagent', () => {
+    const strategy = getStrategy('lcm-subagent')
     expect(strategy).toBeDefined()
     expect(typeof strategy.evaluate).toBe('function')
   })

--- a/src/engine/retrieval.ts
+++ b/src/engine/retrieval.ts
@@ -72,6 +72,49 @@ export function retrievalCost(
 }
 
 /**
+ * Calculate the cost of a single retrieval event for the LCM sub-agent
+ * strategy (4d), which uses a mix of two tools:
+ *
+ * - `lcm_grep` (cheap): retrievalQueryTokens * baseInputPrice + lcmGrepResponseTokens * outputPrice
+ * - `lcm_expand` (expensive): (retrievalQueryTokens + retrievalResponseTokens) * baseInputPrice + retrievalResponseTokens * outputPrice
+ *
+ * The mix is controlled by `lcmGrepRatio` (default 0.70 = 70% grep, 30% expand).
+ */
+export function lcmSubagentRetrievalCost(
+  config: SimulationConfig,
+): StepCost {
+  const grepRatio = config.lcmGrepRatio
+  const expandRatio = 1 - grepRatio
+
+  // lcm_grep cost
+  const grepInput = config.retrievalQueryTokens * config.baseInputPrice
+  const grepOutput = config.lcmGrepResponseTokens * config.outputPrice
+  const grepCost = grepInput + grepOutput
+
+  // lcm_expand cost — query + retrieved content as input, response as output
+  const expandInput =
+    (config.retrievalQueryTokens + config.retrievalResponseTokens) *
+    config.baseInputPrice
+  const expandOutput = config.retrievalResponseTokens * config.outputPrice
+  const expandCost = expandInput + expandOutput
+
+  const blendedCost = grepRatio * grepCost + expandRatio * expandCost
+
+  // Split blended cost into input/output buckets proportionally
+  const totalInput =
+    grepRatio * grepInput + expandRatio * expandInput
+  const totalOutput =
+    grepRatio * grepOutput + expandRatio * expandOutput
+
+  return {
+    ...ZERO_COST,
+    retrievalInput: totalInput,
+    retrievalOutput: totalOutput,
+    total: blendedCost,
+  }
+}
+
+/**
  * Compute the token-weighted average level of entries in an external store.
  * Returns 0 when the store is empty.
  */

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -19,6 +19,7 @@ import {
   createRng,
   retrievalProbability,
   retrievalCost,
+  lcmSubagentRetrievalCost,
   averageStoreLevel,
   type Rng,
 } from './retrieval'
@@ -318,8 +319,12 @@ export function calculateCost(
 
   // Retrieval cost when a retrieval event fired
   if (state.retrievalEvent) {
-    const avgLevel = averageStoreLevel(state.externalStore.entries)
-    stepCost = addCosts(stepCost, retrievalCost(config, avgLevel))
+    if (config.selectedStrategy === 'lcm-subagent') {
+      stepCost = addCosts(stepCost, lcmSubagentRetrievalCost(config))
+    } else {
+      const avgLevel = averageStoreLevel(state.externalStore.entries)
+      stepCost = addCosts(stepCost, retrievalCost(config, avgLevel))
+    }
   }
 
   return {

--- a/src/engine/strategy.ts
+++ b/src/engine/strategy.ts
@@ -354,6 +354,90 @@ export const strategy4c: CompactionStrategy = {
 }
 
 /**
+ * Strategy 4d — LCM sub-agent retrieval.
+ *
+ * Same triggers as Strategy 2 (incremental interval + main threshold), but
+ * every compaction replaces ALL non-system, non-summary content with a single
+ * summary — more aggressive than 4a. All compacted content goes to external
+ * store for later retrieval via dual tools (lcm_grep / lcm_expand).
+ *
+ * Context after compaction: [system] [single_summary]
+ *
+ * Retrieval cost is handled differently from other 4x strategies — see
+ * the `lcmSubagentRetrievalCost` function in retrieval.ts.
+ */
+export const strategy4d: CompactionStrategy = {
+  evaluate(context, config) {
+    const systemMessage = context.messages.find((m) => m.type === 'system')
+    const nonSystemMessages = context.messages.filter(
+      (m) => m.type !== 'system',
+    )
+
+    // Find the last summary — everything after it is "new content"
+    let lastSummaryIndex = -1
+    for (let i = nonSystemMessages.length - 1; i >= 0; i--) {
+      if (nonSystemMessages[i].type === 'summary') {
+        lastSummaryIndex = i
+        break
+      }
+    }
+
+    const newContentMessages = nonSystemMessages.slice(lastSummaryIndex + 1)
+    const newContentTokens = newContentMessages.reduce(
+      (sum, m) => sum + m.tokens,
+      0,
+    )
+
+    const threshold = config.compactionThreshold * config.contextWindow
+    const thresholdExceeded = context.totalTokens > threshold
+
+    if (newContentTokens <= config.incrementalInterval && !thresholdExceeded) {
+      return { shouldCompact: false }
+    }
+
+    // Compact ALL non-system content (including previous summaries) into one summary
+    const allNonSystemTokens = nonSystemMessages.reduce(
+      (sum, m) => sum + m.tokens,
+      0,
+    )
+    const summaryTokens = Math.ceil(allNonSystemTokens / config.compressionRatio)
+    const summaryMessage: Message = {
+      id: `summary-${Date.now()}`,
+      type: 'summary',
+      tokens: summaryTokens,
+      compacted: false,
+    }
+
+    // Store all compacted content in external store
+    const externalStoreEntries: ExternalStoreInput[] = [
+      {
+        originalMessageIds: nonSystemMessages.map((m) => m.id),
+        tokens: allNonSystemTokens,
+        level: 0,
+      },
+    ]
+
+    // Build new context: [system] [single_summary]
+    const newMessages: Message[] = []
+    if (systemMessage) newMessages.push(systemMessage)
+    newMessages.push(summaryMessage)
+
+    const newContext: ContextState = {
+      messages: newMessages,
+      totalTokens: newMessages.reduce((sum, m) => sum + m.tokens, 0),
+    }
+
+    return {
+      shouldCompact: true,
+      newContext,
+      compactedMessageIds: nonSystemMessages.map((m) => m.id),
+      summaryMessage,
+      externalStoreEntries,
+    }
+  },
+}
+
+/**
  * Strategy registry — returns the compaction strategy for a given type.
  */
 export function getStrategy(type: StrategyType): CompactionStrategy {
@@ -368,5 +452,7 @@ export function getStrategy(type: StrategyType): CompactionStrategy {
       return strategy4b
     case 'lossless-tool-results':
       return strategy4c
+    case 'lcm-subagent':
+      return strategy4d
   }
 }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -7,7 +7,7 @@ export type MessageType =
   | 'tool_result'
   | 'summary'
 
-export type StrategyType = 'full-compaction' | 'incremental' | 'lossless-append' | 'lossless-hierarchical' | 'lossless-tool-results'
+export type StrategyType = 'full-compaction' | 'incremental' | 'lossless-append' | 'lossless-hierarchical' | 'lossless-tool-results' | 'lcm-subagent'
 
 export interface Message {
   readonly id: string


### PR DESCRIPTION
## Summary

- Implements strategy 4d with aggressive full compaction (all non-system content → single summary) and external store
- Adds dual retrieval cost model: `lcm_grep` (cheap) and `lcm_expand` (expensive), blended by configurable `lcmGrepRatio`
- UI: strategy selector, conditional params (`lcmGrepRatio`, `lcmGrepResponseTokens`), stat cards, external store visualisation

Closes #31

## Test plan

- [x] All 155 tests pass (including new strategy4d and lcmSubagentRetrievalCost tests)
- [x] Build succeeds
- [x] Lint passes (pre-existing warning only)
- [x] Manual: select 4d in UI and verify end-to-end simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)