### PR TITLE
Replace reviewer agent with code-review skill

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,6 +1,15 @@
-# Reviewer — compact-sim
+---
+name: code-review
+description: "Code review a pull request. Usage: /code-review <PR number>"
+---
+
+# Code Review — compact-sim
 
 Review a PR for code quality and adherence to spec/plan.
+
+## Arguments
+
+- `/code-review <PR number>` — Review the specified pull request
 
 ## Instructions
 
@@ -14,11 +23,13 @@ Review a PR for code quality and adherence to spec/plan.
    - Are there tests? Are they meaningful?
    - Does it follow the repo's coding conventions?
    - Are simulation models mathematically sound?
+   - Effect used only in simulation engine layer (not React UI)?
    - Any obvious bugs or edge cases?
 7. Report findings
 
 ## Output Format
 
+```markdown
 ### PR Review: #N — [title]
 
 **Plan Compliance:** [Good/Partial/Poor] — [brief note]
@@ -26,8 +37,10 @@ Review a PR for code quality and adherence to spec/plan.
 **Code Quality:** [observations]
 **Issues Found:** [list or "None"]
 **Recommendation:** [Approve / Request Changes / Needs Discussion]
+```
 
 ## Behaviour Notes
+
 - Do NOT write code or make changes
 - Do NOT merge PRs
 - Be constructive — flag issues but also note what's done well

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Key modelling concepts:
 
 ## Conventions
 
+- `/code-review <pr>` — PR code review
 - Specs: `specs/`, Plans: `plans/`
 - Default branch: `main`
 - **Never use compound Bash commands** (no `&&`, `;`, or `|` chaining). Use separate Bash tool calls instead — independent calls can run in parallel. Compound commands trigger extra permission prompts.


### PR DESCRIPTION
## Summary
- Add `/code-review` skill with repo-specific review criteria (simulation model soundness, Effect layer boundaries)
- Delete the unused agents directory (reviewer agent relied on broken auto-discovery)
- Update CLAUDE.md to reference the new skill

Part of TagloGit/taglo-pm#25

## Test plan
- [x] Verify `/code-review` skill appears in Claude Code session
- [x] Run `/code-review` against an existing PR to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)