### PR TITLE
Tab infrastructure: Simulator and Explorer tabs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,10 @@ export default defineConfig([
         'warn',
         { allowConstantExport: true },
       ],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
     },
   },
 ])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,168 +1,42 @@
+import { useState, useCallback } from 'react'
+import type { SimulationConfig } from '@/engine/types'
 import { useSimulation } from '@/hooks/useSimulation'
-import { AppLayout } from '@/components/layout/AppLayout'
-import { ParameterPanel } from '@/components/controls/ParameterPanel'
-import { PlaybackControls } from '@/components/controls/PlaybackControls'
-import { ContextStack } from '@/components/visualisations/ContextStack'
-import { ContextSizeChart } from '@/components/visualisations/ContextSizeChart'
-import { CostChart } from '@/components/visualisations/CostChart'
-import { CacheHitRate } from '@/components/visualisations/CacheHitRate'
-import { CostPerStepChart } from '@/components/visualisations/CostPerStepChart'
-import { ExternalStore } from '@/components/visualisations/ExternalStore'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { SimulatorTab } from '@/components/SimulatorTab'
+import { ExplorerTab } from '@/components/ExplorerTab'
 
-function formatCost(dollars: number): string {
-  if (dollars < 0.01) return `$${dollars.toFixed(4)}`
-  return `$${dollars.toFixed(2)}`
-}
-
-function formatTokens(tokens: number): string {
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`
-  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`
-  return String(tokens)
-}
+type TabValue = 'simulator' | 'explorer'
 
 function App() {
-  const { config, updateConfig, result, currentStep, setCurrentStep, currentSnapshot } = useSimulation()
+  const [activeTab, setActiveTab] = useState<TabValue>('simulator')
+  const simulation = useSimulation()
+
+  const openInSimulator = useCallback((config: SimulationConfig) => {
+    simulation.setConfig(config)
+    setActiveTab('simulator')
+  }, [simulation])
 
   return (
-    <AppLayout
-      sidebar={<ParameterPanel config={config} onUpdate={updateConfig} />}
+    <Tabs
+      value={activeTab}
+      onValueChange={(value) => setActiveTab(value as TabValue)}
+      className="h-screen"
     >
-      <div className="space-y-6">
-        <div>
-          <h1 className="text-xl font-semibold">Compaction Simulator</h1>
-          <p className="text-sm text-muted-foreground">
-            {config.selectedStrategy === 'full-compaction' && 'Strategy 1 — Full compaction at threshold'}
-            {config.selectedStrategy === 'incremental' && 'Strategy 2 — Incremental compaction at intervals'}
-            {config.selectedStrategy === 'lossless-append' && 'Strategy 4a — Lossless append-only with external retrieval'}
-            {config.selectedStrategy === 'lossless-hierarchical' && 'Strategy 4b — Lossless hierarchical with levelled external retrieval'}
-            {config.selectedStrategy === 'lossless-tool-results' && 'Strategy 4c — Tool-results-only lossless with external retrieval'}
-            {config.selectedStrategy === 'lcm-subagent' && 'Strategy 4d — LCM sub-agent retrieval (grep + expand)'}
-            {config.toolCompressionEnabled && ' + tool result compression'}
-          </p>
+      <div className="flex h-full flex-col">
+        <div className="shrink-0 border-b border-border bg-card px-4">
+          <TabsList variant="line">
+            <TabsTrigger value="simulator">Simulator</TabsTrigger>
+            <TabsTrigger value="explorer">Explorer</TabsTrigger>
+          </TabsList>
         </div>
-
-        {result && currentSnapshot ? (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <StatCard
-              label="Step"
-              value={`${currentStep + 1} / ${result.snapshots.length}`}
-            />
-            <StatCard
-              label="Context Size"
-              value={formatTokens(currentSnapshot.context.totalTokens)}
-              sub={`${Math.round((currentSnapshot.context.totalTokens / config.contextWindow) * 100)}% of window`}
-            />
-            <StatCard
-              label="Total Cost"
-              value={formatCost(currentSnapshot.cumulativeCost.total)}
-            />
-            <StatCard
-              label="Compaction Events"
-              value={String(result.summary.compactionEvents)}
-            />
-          </div>
-        ) : (
-          <p className="text-sm text-muted-foreground">Running simulation...</p>
-        )}
-
-        {result && (
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <StatCard
-              label="Peak Context"
-              value={formatTokens(result.summary.peakContextSize)}
-            />
-            <StatCard
-              label="Avg Cache Hit Rate"
-              value={`${(result.summary.averageCacheHitRate * 100).toFixed(1)}%`}
-            />
-            <StatCard
-              label="Total Tokens Generated"
-              value={formatTokens(result.summary.totalTokensGenerated)}
-            />
-            <StatCard
-              label="Final Cost"
-              value={formatCost(result.summary.totalCost)}
-            />
-            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
-              <>
-                <StatCard
-                  label="External Store"
-                  value={formatTokens(result.snapshots[result.snapshots.length - 1].externalStore.totalTokens)}
-                  sub={`${result.snapshots[result.snapshots.length - 1].externalStore.entries.length} entries`}
-                />
-                <StatCard
-                  label="Retrieval Events"
-                  value={String(result.snapshots.filter((s) => s.retrievalEvent).length)}
-                />
-              </>
-            )}
-          </div>
-        )}
-
-        {/* Playback controls */}
-        {result && (
-          <PlaybackControls
-            currentStep={currentStep}
-            totalSteps={result.snapshots.length}
-            onStepChange={setCurrentStep}
-          />
-        )}
-
-        {/* Context stack visualisation */}
-        {currentSnapshot && (
-          <ContextStack
-            snapshot={currentSnapshot}
-            contextWindow={config.contextWindow}
-          />
-        )}
-
-        {/* External store visualisation (4x strategies only) */}
-        {currentSnapshot && (config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
-          <ExternalStore
-            snapshot={currentSnapshot}
-            contextWindow={config.contextWindow}
-          />
-        )}
-
-        {/* Charts: context size + cache left, cumulative cost + per-step cost right */}
-        {result && (
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-            <div className="flex flex-col gap-4">
-              <ContextSizeChart
-                snapshots={result.snapshots}
-                currentStep={currentStep}
-                contextWindow={config.contextWindow}
-                compactionThreshold={config.compactionThreshold}
-              />
-              <CacheHitRate
-                snapshots={result.snapshots}
-                currentStep={currentStep}
-              />
-            </div>
-            <div className="flex flex-col gap-4">
-              <CostChart
-                snapshots={result.snapshots}
-                currentStep={currentStep}
-              />
-              <CostPerStepChart
-                snapshots={result.snapshots}
-                currentStep={currentStep}
-              />
-            </div>
-          </div>
-        )}
+        <TabsContent value="simulator" className="min-h-0 flex-1">
+          <SimulatorTab simulation={simulation} />
+        </TabsContent>
+        <TabsContent value="explorer" className="min-h-0 flex-1">
+          <ExplorerTab onOpenInSimulator={openInSimulator} />
+        </TabsContent>
       </div>
-    </AppLayout>
-  )
-}
-
-function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <div className="rounded-lg border border-border bg-card p-3">
-      <p className="text-xs text-muted-foreground">{label}</p>
-      <p className="text-lg font-semibold tabular-nums">{value}</p>
-      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
-    </div>
+    </Tabs>
   )
 }
 

--- a/src/components/ExplorerTab.tsx
+++ b/src/components/ExplorerTab.tsx
@@ -1,0 +1,33 @@
+import type { SimulationConfig } from '@/engine/types'
+import { AppLayout } from '@/components/layout/AppLayout'
+
+interface ExplorerTabProps {
+  onOpenInSimulator: (config: SimulationConfig) => void
+}
+
+export function ExplorerTab(_props: ExplorerTabProps) {
+  return (
+    <AppLayout
+      sidebar={
+        <div className="p-4">
+          <h2 className="text-sm font-semibold">Sweep Parameters</h2>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Coming soon — configure parameter ranges and run sweeps.
+          </p>
+        </div>
+      }
+    >
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold">Parameter Sweep Explorer</h1>
+          <p className="text-sm text-muted-foreground">
+            Define parameter ranges, run the cartesian product, and explore results as a heat bar.
+          </p>
+        </div>
+        <div className="flex items-center justify-center rounded-lg border border-dashed border-border p-12 text-muted-foreground">
+          Explorer components will be added in subsequent issues.
+        </div>
+      </div>
+    </AppLayout>
+  )
+}

--- a/src/components/SimulatorTab.tsx
+++ b/src/components/SimulatorTab.tsx
@@ -1,0 +1,171 @@
+import type { UseSimulationReturn } from '@/hooks/useSimulation'
+import { ParameterPanel } from '@/components/controls/ParameterPanel'
+import { PlaybackControls } from '@/components/controls/PlaybackControls'
+import { ContextStack } from '@/components/visualisations/ContextStack'
+import { ContextSizeChart } from '@/components/visualisations/ContextSizeChart'
+import { CostChart } from '@/components/visualisations/CostChart'
+import { CacheHitRate } from '@/components/visualisations/CacheHitRate'
+import { CostPerStepChart } from '@/components/visualisations/CostPerStepChart'
+import { ExternalStore } from '@/components/visualisations/ExternalStore'
+import { AppLayout } from '@/components/layout/AppLayout'
+
+function formatCost(dollars: number): string {
+  if (dollars < 0.01) return `$${dollars.toFixed(4)}`
+  return `$${dollars.toFixed(2)}`
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`
+  return String(tokens)
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold tabular-nums">{value}</p>
+      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
+    </div>
+  )
+}
+
+interface SimulatorTabProps {
+  simulation: UseSimulationReturn
+}
+
+export function SimulatorTab({ simulation }: SimulatorTabProps) {
+  const { config, updateConfig, result, currentStep, setCurrentStep, currentSnapshot } = simulation
+
+  return (
+    <AppLayout
+      sidebar={<ParameterPanel config={config} onUpdate={updateConfig} />}
+    >
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold">Compaction Simulator</h1>
+          <p className="text-sm text-muted-foreground">
+            {config.selectedStrategy === 'full-compaction' && 'Strategy 1 — Full compaction at threshold'}
+            {config.selectedStrategy === 'incremental' && 'Strategy 2 — Incremental compaction at intervals'}
+            {config.selectedStrategy === 'lossless-append' && 'Strategy 4a — Lossless append-only with external retrieval'}
+            {config.selectedStrategy === 'lossless-hierarchical' && 'Strategy 4b — Lossless hierarchical with levelled external retrieval'}
+            {config.selectedStrategy === 'lossless-tool-results' && 'Strategy 4c — Tool-results-only lossless with external retrieval'}
+            {config.selectedStrategy === 'lcm-subagent' && 'Strategy 4d — LCM sub-agent retrieval (grep + expand)'}
+            {config.toolCompressionEnabled && ' + tool result compression'}
+          </p>
+        </div>
+
+        {result && currentSnapshot ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <StatCard
+              label="Step"
+              value={`${currentStep + 1} / ${result.snapshots.length}`}
+            />
+            <StatCard
+              label="Context Size"
+              value={formatTokens(currentSnapshot.context.totalTokens)}
+              sub={`${Math.round((currentSnapshot.context.totalTokens / config.contextWindow) * 100)}% of window`}
+            />
+            <StatCard
+              label="Total Cost"
+              value={formatCost(currentSnapshot.cumulativeCost.total)}
+            />
+            <StatCard
+              label="Compaction Events"
+              value={String(result.summary.compactionEvents)}
+            />
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">Running simulation...</p>
+        )}
+
+        {result && (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <StatCard
+              label="Peak Context"
+              value={formatTokens(result.summary.peakContextSize)}
+            />
+            <StatCard
+              label="Avg Cache Hit Rate"
+              value={`${(result.summary.averageCacheHitRate * 100).toFixed(1)}%`}
+            />
+            <StatCard
+              label="Total Tokens Generated"
+              value={formatTokens(result.summary.totalTokensGenerated)}
+            />
+            <StatCard
+              label="Final Cost"
+              value={formatCost(result.summary.totalCost)}
+            />
+            {(config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
+              <>
+                <StatCard
+                  label="External Store"
+                  value={formatTokens(result.snapshots[result.snapshots.length - 1].externalStore.totalTokens)}
+                  sub={`${result.snapshots[result.snapshots.length - 1].externalStore.entries.length} entries`}
+                />
+                <StatCard
+                  label="Retrieval Events"
+                  value={String(result.snapshots.filter((s) => s.retrievalEvent).length)}
+                />
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Playback controls */}
+        {result && (
+          <PlaybackControls
+            currentStep={currentStep}
+            totalSteps={result.snapshots.length}
+            onStepChange={setCurrentStep}
+          />
+        )}
+
+        {/* Context stack visualisation */}
+        {currentSnapshot && (
+          <ContextStack
+            snapshot={currentSnapshot}
+            contextWindow={config.contextWindow}
+          />
+        )}
+
+        {/* External store visualisation (4x strategies only) */}
+        {currentSnapshot && (config.selectedStrategy === 'lossless-append' || config.selectedStrategy === 'lossless-hierarchical' || config.selectedStrategy === 'lossless-tool-results' || config.selectedStrategy === 'lcm-subagent') && (
+          <ExternalStore
+            snapshot={currentSnapshot}
+            contextWindow={config.contextWindow}
+          />
+        )}
+
+        {/* Charts: context size + cache left, cumulative cost + per-step cost right */}
+        {result && (
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <div className="flex flex-col gap-4">
+              <ContextSizeChart
+                snapshots={result.snapshots}
+                currentStep={currentStep}
+                contextWindow={config.contextWindow}
+                compactionThreshold={config.compactionThreshold}
+              />
+              <CacheHitRate
+                snapshots={result.snapshots}
+                currentStep={currentStep}
+              />
+            </div>
+            <div className="flex flex-col gap-4">
+              <CostChart
+                snapshots={result.snapshots}
+                currentStep={currentStep}
+              />
+              <CostPerStepChart
+                snapshots={result.snapshots}
+                currentStep={currentStep}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  )
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,80 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }


### PR DESCRIPTION
## Summary
- Extract existing simulator UI from `App.tsx` into a `SimulatorTab` component — no behaviour changes
- Add `ExplorerTab` placeholder with `onOpenInSimulator` callback prop for future "Open in Simulator" flow
- `App.tsx` now renders Simulator/Explorer tab navigation using shadcn/ui Tabs (line variant)
- Allow underscore-prefixed unused vars in ESLint config (standard convention for intentionally unused params)

Closes #43

## Test plan
- [x] Verify simulator tab works identically to before (all strategies, playback, charts)
- [x] Verify Explorer tab shows placeholder content
- [x] Verify tab switching preserves simulator state
- [x] `npm run build` passes
- [x] `npm test` passes (155 tests)
- [x] `npm run lint` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)