### PR TITLE
Extract conversation reuse from simulation engine

### DIFF
--- a/src/engine/__tests__/simulation.test.ts
+++ b/src/engine/__tests__/simulation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { Effect } from 'effect'
-import { runSimulation } from '../simulation'
+import { runSimulation, runSimulationWithConversation } from '../simulation'
+import { generateConversation } from '../conversation'
 import type { SimulationConfig } from '../types'
 import { DEFAULT_CONFIG } from '../types'
 
@@ -659,6 +660,38 @@ describe('runSimulation', () => {
         expect(lastRetrieval.cost.retrievalInput).toBeGreaterThanOrEqual(
           firstRetrieval.cost.retrievalInput,
         )
+      }
+    })
+  })
+
+  describe('runSimulationWithConversation', () => {
+    it('produces identical results to runSimulation for the same config', () => {
+      const config: SimulationConfig = {
+        ...DEFAULT_CONFIG,
+        toolCallCycles: 10,
+        toolCallSize: 200,
+        toolResultSize: 2_000,
+        assistantMessageSize: 300,
+        reasoningOutputSize: 0,
+        userMessageFrequency: 100,
+        userMessageSize: 200,
+        systemPromptSize: 4_000,
+        contextWindow: 10_000,
+        compactionThreshold: 0.8,
+        compressionRatio: 10,
+      }
+
+      // Generate conversation separately, then run both paths
+      const messages = Effect.runSync(generateConversation(config))
+      const fromRunSimulation = run(config)
+      const fromWithConversation = runSimulationWithConversation(config, messages)
+
+      expect(fromWithConversation.summary).toEqual(fromRunSimulation.summary)
+      expect(fromWithConversation.snapshots.length).toBe(fromRunSimulation.snapshots.length)
+      for (let i = 0; i < fromWithConversation.snapshots.length; i++) {
+        expect(fromWithConversation.snapshots[i].cost).toEqual(fromRunSimulation.snapshots[i].cost)
+        expect(fromWithConversation.snapshots[i].cumulativeCost).toEqual(fromRunSimulation.snapshots[i].cumulativeCost)
+        expect(fromWithConversation.snapshots[i].context.totalTokens).toBe(fromRunSimulation.snapshots[i].context.totalTokens)
       }
     })
   })

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -359,73 +359,82 @@ export function buildSnapshot(
 }
 
 // ---------------------------------------------------------------------------
-// Main simulation runner
+// Simulation runner (conversation provided)
+// ---------------------------------------------------------------------------
+
+export function runSimulationWithConversation(
+  config: SimulationConfig,
+  allMessages: readonly Message[],
+): SimulationResult {
+  const snapshots: SimulationSnapshot[] = []
+  let totalTokensGenerated = 0
+
+  let state: StepState = {
+    conversation: [],
+    context: { messages: [], totalTokens: 0 },
+    previousContext: null,
+    externalStore: EMPTY_EXTERNAL_STORE,
+    compressedTokens: 0,
+    summaryCounter: 0,
+    cumulativeCost: ZERO_COST,
+    peakContextSize: 0,
+    rng: createRng(42),
+    // Per-step transient (reset in ingestMessage)
+    compactionEvent: false,
+    retrievalEvent: false,
+    tokensCompacted: 0,
+    summaryTokens: 0,
+    pendingStoreEntries: [],
+    cache: ZERO_CACHE,
+    stepCost: ZERO_COST,
+  }
+
+  for (let i = 0; i < allMessages.length; i++) {
+    state = ingestMessage(state, allMessages[i], config)
+
+    // The processed message (with tool compression applied) is the last in conversation
+    const message = state.conversation[state.conversation.length - 1]
+
+    state = buildContext(state)
+    state = evaluateCompaction(state, config)
+    state = updateExternalStore(state, config)
+    state = calculateCache(state, message, config)
+    state = rollRetrieval(state, message, config)
+    state = calculateCost(state, message, config)
+
+    totalTokensGenerated += message.tokens
+
+    snapshots.push(buildSnapshot(state, message, i))
+  }
+
+  // Calculate average cache hit rate across LLM call steps
+  const llmSteps = snapshots.filter((s) => isLlmCallStep(s.message))
+  const averageCacheHitRate =
+    llmSteps.length > 0
+      ? llmSteps.reduce((sum, s) => sum + s.cache.hitRate, 0) /
+        llmSteps.length
+      : 0
+
+  return {
+    config,
+    snapshots,
+    summary: {
+      totalCost: state.cumulativeCost.total,
+      totalTokensGenerated,
+      compactionEvents: snapshots.filter((s) => s.compactionEvent).length,
+      averageCacheHitRate,
+      peakContextSize: state.peakContextSize,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main simulation runner (generates conversation, then simulates)
 // ---------------------------------------------------------------------------
 
 export const runSimulation = (
   config: SimulationConfig,
 ): Effect.Effect<SimulationResult> =>
   Effect.flatMap(generateConversation(config), (allMessages) =>
-    Effect.sync(() => {
-      const snapshots: SimulationSnapshot[] = []
-      let totalTokensGenerated = 0
-
-      let state: StepState = {
-        conversation: [],
-        context: { messages: [], totalTokens: 0 },
-        previousContext: null,
-        externalStore: EMPTY_EXTERNAL_STORE,
-        compressedTokens: 0,
-        summaryCounter: 0,
-        cumulativeCost: ZERO_COST,
-        peakContextSize: 0,
-        rng: createRng(42),
-        // Per-step transient (reset in ingestMessage)
-        compactionEvent: false,
-        retrievalEvent: false,
-        tokensCompacted: 0,
-        summaryTokens: 0,
-        pendingStoreEntries: [],
-        cache: ZERO_CACHE,
-        stepCost: ZERO_COST,
-      }
-
-      for (let i = 0; i < allMessages.length; i++) {
-        state = ingestMessage(state, allMessages[i], config)
-
-        // The processed message (with tool compression applied) is the last in conversation
-        const message = state.conversation[state.conversation.length - 1]
-
-        state = buildContext(state)
-        state = evaluateCompaction(state, config)
-        state = updateExternalStore(state, config)
-        state = calculateCache(state, message, config)
-        state = rollRetrieval(state, message, config)
-        state = calculateCost(state, message, config)
-
-        totalTokensGenerated += message.tokens
-
-        snapshots.push(buildSnapshot(state, message, i))
-      }
-
-      // Calculate average cache hit rate across LLM call steps
-      const llmSteps = snapshots.filter((s) => isLlmCallStep(s.message))
-      const averageCacheHitRate =
-        llmSteps.length > 0
-          ? llmSteps.reduce((sum, s) => sum + s.cache.hitRate, 0) /
-            llmSteps.length
-          : 0
-
-      return {
-        config,
-        snapshots,
-        summary: {
-          totalCost: state.cumulativeCost.total,
-          totalTokensGenerated,
-          compactionEvents: snapshots.filter((s) => s.compactionEvent).length,
-          averageCacheHitRate,
-          peakContextSize: state.peakContextSize,
-        },
-      }
-    }),
+    Effect.sync(() => runSimulationWithConversation(config, allMessages)),
   )


### PR DESCRIPTION
## Summary
- Extract `runSimulationWithConversation(config, messages)` from `runSimulation` so callers can provide pre-generated conversations
- `runSimulation` delegates to the new function — all existing behaviour unchanged
- Add test verifying both paths produce identical results

Closes #47

## Test plan
- [x] All 172 existing tests pass without modification
- [x] New test confirms `runSimulationWithConversation` produces identical output to `runSimulation`
- [x] Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)