### PR TITLE
Add web worker and useSweep hook

### DIFF
--- a/src/components/ExplorerTab.tsx
+++ b/src/components/ExplorerTab.tsx
@@ -1,13 +1,8 @@
-import { useState, useMemo, useCallback, useRef } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import type { SimulationConfig } from '@/engine/types'
-import type {
-  SweepConfig,
-  SweepParameterDef,
-  SweepRunResult,
-  SweepMetrics,
-} from '@/engine/sweep-types'
-import { buildDefaultSweepConfig } from '@/engine/sweep-defaults'
-import { expandSweepConfig, expandParamValues } from '@/engine/sweep'
+import type { SweepParameterDef } from '@/engine/sweep-types'
+import { expandParamValues } from '@/engine/sweep'
+import { useSweep } from '@/hooks/useSweep'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { SweepParameterPanel } from '@/components/explorer/SweepParameterPanel'
 import { CombinationCounter } from '@/components/explorer/CombinationCounter'
@@ -20,79 +15,9 @@ interface ExplorerTabProps {
   onOpenInSimulator: (config: SimulationConfig) => void
 }
 
-// --- Mock data generation ---
-
-/** Generate mock SweepRunResult[] from a SweepConfig, ordered by variableOrder */
-function generateMockResults(
-  config: SweepConfig,
-  variableOrder: (keyof SimulationConfig)[],
-): SweepRunResult[] {
-  // Reorder the sweep config so variableOrder keys come first (affects cartesian product order)
-  const allKeys = Object.keys(config) as (keyof SimulationConfig)[]
-  const orderedKeys = [
-    ...variableOrder,
-    ...allKeys.filter((k) => !variableOrder.includes(k)),
-  ]
-  const reorderedConfig = Object.fromEntries(
-    orderedKeys.map((k) => [k, config[k]]),
-  ) as SweepConfig
-
-  const expanded = expandSweepConfig(reorderedConfig)
-  return expanded.map((simConfig, i) => ({
-    index: i,
-    config: simConfig,
-    metrics: generateMockMetrics(simConfig, i, expanded.length),
-  }))
-}
-
-/** Generate plausible mock metrics that vary with config parameters */
-function generateMockMetrics(config: SimulationConfig, index: number, _total: number): SweepMetrics {
-  // Use a simple seeded pseudo-random for reproducibility
-  const seed = index * 2654435761 // Knuth multiplicative hash
-  const rand = () => {
-    const x = Math.sin(seed + index * 127.1) * 43758.5453
-    return x - Math.floor(x)
-  }
-
-  // Cost varies with context window, tool result size, and cycles
-  const sizeFactor = config.toolResultSize / 10_000
-  const cycleFactor = config.toolCallCycles / 100
-  const windowFactor = config.contextWindow / 200_000
-  const baseCost = 0.5 + sizeFactor * cycleFactor * windowFactor * 2
-
-  // Add variation based on compression ratio and strategy
-  const compressionSaving = 1 / config.compressionRatio
-  const noise = (rand() - 0.5) * 0.3
-
-  const totalCost = Math.max(0.01, baseCost * (1 - compressionSaving * 0.3) + noise)
-  const peakContextSize = Math.round(config.contextWindow * (0.6 + rand() * 0.35) * config.compactionThreshold)
-  const compactionEvents = Math.max(0, Math.round(cycleFactor * 3 + (rand() - 0.5) * 4))
-  const averageCacheHitRate = Math.min(0.95, Math.max(0.1, 0.5 + (1 - compressionSaving) * 0.2 + (rand() - 0.5) * 0.2))
-  const externalStoreSize = config.selectedStrategy.startsWith('lossless')
-    ? Math.round(peakContextSize * 0.3 * (1 + rand()))
-    : 0
-  const totalRetrievalCost = externalStoreSize > 0
-    ? totalCost * 0.05 * (1 + rand())
-    : 0
-
-  return {
-    totalCost,
-    peakContextSize,
-    compactionEvents,
-    averageCacheHitRate,
-    externalStoreSize,
-    totalRetrievalCost,
-  }
-}
-
-// --- Component ---
-
 export function ExplorerTab({ onOpenInSimulator }: ExplorerTabProps) {
-  const [sweepConfig, setSweepConfig] = useState<SweepConfig>(buildDefaultSweepConfig)
+  const { sweepConfig, setSweepConfig, results, progress, isRunning, run, reorder, cancel } = useSweep()
   const [selectedMetric, setSelectedMetric] = useState<MetricKey>('totalCost')
-  const [isRunning, setIsRunning] = useState(false)
-  const [progress, setProgress] = useState(0)
-  const [results, setResults] = useState<SweepRunResult[]>([])
   const [selectedRunIndex, setSelectedRunIndex] = useState<number | null>(null)
 
   // Swept keys — only params with kind 'swept'
@@ -107,7 +32,6 @@ export function ExplorerTab({ onOpenInSimulator }: ExplorerTabProps) {
 
   // Keep variable order in sync with swept keys
   const effectiveOrder = useMemo(() => {
-    // Keep existing order entries that are still swept, add new swept keys at end
     const stillSwept = variableOrder.filter((k) => sweptKeys.includes(k))
     const newSwept = sweptKeys.filter((k) => !variableOrder.includes(k))
     return [...stillSwept, ...newSwept]
@@ -121,50 +45,25 @@ export function ExplorerTab({ onOpenInSimulator }: ExplorerTabProps) {
     )
   }, [sweepConfig, sweptKeys])
 
-  const intervalRef = useRef<ReturnType<typeof setInterval>>(null)
-
   const handleRun = useCallback(() => {
-    setIsRunning(true)
-    setProgress(0)
     setSelectedRunIndex(null)
-
-    // Generate mock results
-    const mockResults = generateMockResults(sweepConfig, effectiveOrder)
-
-    // Animate progress, then set results
-    let p = 0
-    intervalRef.current = setInterval(() => {
-      p += 0.1
-      if (p >= 1) {
-        p = 1
-        if (intervalRef.current) clearInterval(intervalRef.current)
-        intervalRef.current = null
-        setIsRunning(false)
-        setResults(mockResults)
-      }
-      setProgress(p)
-    }, 150)
-  }, [sweepConfig, effectiveOrder])
+    run(effectiveOrder)
+  }, [run, effectiveOrder])
 
   const handleCancel = useCallback(() => {
-    if (intervalRef.current) clearInterval(intervalRef.current)
-    intervalRef.current = null
-    setIsRunning(false)
-    setProgress(0)
-  }, [])
+    cancel()
+  }, [cancel])
 
-  // When variable order changes, re-sort existing results
+  // When variable order changes, re-sort existing results without re-running
   const handleOrderChange = useCallback(
     (newOrder: (keyof SimulationConfig)[]) => {
       setVariableOrder(newOrder)
       if (results.length > 0) {
-        // Re-generate with new ordering
-        const reordered = generateMockResults(sweepConfig, newOrder)
-        setResults(reordered)
+        reorder(newOrder)
         setSelectedRunIndex(null)
       }
     },
-    [results.length, sweepConfig],
+    [results.length, reorder],
   )
 
   const selectedResult = selectedRunIndex !== null ? results[selectedRunIndex] ?? null : null

--- a/src/engine/__tests__/sweep-worker.test.ts
+++ b/src/engine/__tests__/sweep-worker.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import { Effect } from 'effect'
+import { DEFAULT_CONFIG } from '../types'
+import type { SimulationConfig } from '../types'
+import type { SweepConfig } from '../sweep-types'
+import { buildDefaultSweepConfig } from '../sweep-defaults'
+import { expandSweepConfig, partitionByShape } from '../sweep'
+import { generateConversation } from '../conversation'
+import { runSimulationWithConversation } from '../simulation'
+import { generateConversationSync } from '../sweep-worker-protocol'
+
+/** Helper: build a SweepConfig with overrides */
+function sweepConfig(overrides: Partial<SweepConfig>): SweepConfig {
+  return { ...buildDefaultSweepConfig(), ...overrides }
+}
+
+/** Small config for fast tests */
+const SMALL_CONFIG: SimulationConfig = {
+  ...DEFAULT_CONFIG,
+  toolCallCycles: 3,
+  contextWindow: 20_000,
+  compactionThreshold: 0.8,
+}
+
+describe('generateConversationSync', () => {
+  it('produces the same messages as the Effect-wrapped version', () => {
+    const syncMessages = generateConversationSync(SMALL_CONFIG)
+    const effectMessages = Effect.runSync(generateConversation(SMALL_CONFIG))
+    expect(syncMessages).toEqual(effectMessages)
+  })
+})
+
+describe('sweep worker integration', () => {
+  it('runs a small sweep with correct result count', () => {
+    // 3 swept params × 2 steps each = 8 combinations
+    const config = sweepConfig({
+      compactionThreshold: {
+        kind: 'swept',
+        min: 0.7,
+        max: 0.9,
+        steps: 2,
+        scale: 'linear',
+      },
+      compressionRatio: {
+        kind: 'swept',
+        min: 5,
+        max: 10,
+        steps: 2,
+        scale: 'linear',
+      },
+      contextWindow: {
+        kind: 'swept',
+        min: 20_000,
+        max: 50_000,
+        steps: 2,
+        scale: 'linear',
+      },
+    })
+
+    const expanded = expandSweepConfig(config)
+    expect(expanded).toHaveLength(8)
+
+    // Partition by shape and generate conversations
+    const groups = partitionByShape(expanded)
+
+    // All 8 configs share the same conversation shape (only non-shape params swept)
+    expect(groups.size).toBe(1)
+
+    // Run each config through the simulation
+    const results = expanded.map((simConfig, i) => {
+      const messages = generateConversationSync(simConfig)
+      const result = runSimulationWithConversation(simConfig, messages)
+      const lastSnapshot = result.snapshots[result.snapshots.length - 1]
+
+      return {
+        index: i,
+        config: simConfig,
+        metrics: {
+          totalCost: result.summary.totalCost,
+          peakContextSize: result.summary.peakContextSize,
+          compactionEvents: result.summary.compactionEvents,
+          averageCacheHitRate: result.summary.averageCacheHitRate,
+          externalStoreSize: lastSnapshot?.externalStore.totalTokens ?? 0,
+          totalRetrievalCost: lastSnapshot
+            ? lastSnapshot.cumulativeCost.retrievalInput +
+              lastSnapshot.cumulativeCost.retrievalOutput
+            : 0,
+        },
+      }
+    })
+
+    expect(results).toHaveLength(8)
+
+    // Each result should have valid metrics
+    for (const r of results) {
+      expect(r.metrics.totalCost).toBeGreaterThan(0)
+      expect(r.metrics.peakContextSize).toBeGreaterThan(0)
+      expect(r.metrics.averageCacheHitRate).toBeGreaterThanOrEqual(0)
+      expect(r.metrics.averageCacheHitRate).toBeLessThanOrEqual(1)
+      expect(r.metrics.compactionEvents).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('conversation reuse produces identical results for same shape', () => {
+    const config = sweepConfig({
+      compressionRatio: {
+        kind: 'swept',
+        min: 5,
+        max: 10,
+        steps: 2,
+        scale: 'linear',
+      },
+    })
+
+    const expanded = expandSweepConfig(config)
+    expect(expanded).toHaveLength(2)
+
+    // Both configs share conversation shape — generate once
+    const messages = generateConversationSync(expanded[0])
+
+    const result1 = runSimulationWithConversation(expanded[0], messages)
+    const result2 = runSimulationWithConversation(expanded[1], messages)
+
+    // Same conversation, different configs — should produce different costs
+    expect(result1.summary.totalCost).not.toBe(result2.summary.totalCost)
+
+    // But same number of snapshots (same conversation)
+    expect(result1.snapshots.length).toBe(result2.snapshots.length)
+  })
+
+  it('partitions correctly when conversation shape params are swept', () => {
+    const config = sweepConfig({
+      toolCallCycles: {
+        kind: 'swept',
+        min: 3,
+        max: 5,
+        steps: 2,
+        scale: 'linear',
+      },
+      compressionRatio: {
+        kind: 'swept',
+        min: 5,
+        max: 10,
+        steps: 2,
+        scale: 'linear',
+      },
+    })
+
+    const expanded = expandSweepConfig(config)
+    expect(expanded).toHaveLength(4)
+
+    const groups = partitionByShape(expanded)
+    // toolCallCycles is a conversation shape param → 2 groups
+    expect(groups.size).toBe(2)
+
+    // Each group has 2 configs (the 2 compressionRatio values)
+    for (const group of groups.values()) {
+      expect(group).toHaveLength(2)
+    }
+  })
+
+  it('produces deterministic results for the same config', () => {
+    const messages = generateConversationSync(SMALL_CONFIG)
+    const result1 = runSimulationWithConversation(SMALL_CONFIG, messages)
+    const result2 = runSimulationWithConversation(SMALL_CONFIG, messages)
+
+    expect(result1.summary).toEqual(result2.summary)
+  })
+})

--- a/src/engine/sweep-worker-protocol.ts
+++ b/src/engine/sweep-worker-protocol.ts
@@ -1,0 +1,66 @@
+import { Effect } from 'effect'
+import type { Message, SimulationConfig } from './types'
+import type { SweepMetrics, SweepRunResult } from './sweep-types'
+import { generateConversation } from './conversation'
+import { runSimulationWithConversation } from './simulation'
+
+// --- Worker message protocol ---
+
+export interface WorkerBatch {
+  readonly kind: 'batch'
+  readonly runs: readonly WorkerRun[]
+  readonly batchOffset: number // global index offset for this batch
+}
+
+export interface WorkerRun {
+  readonly config: SimulationConfig
+  readonly messages: readonly Message[]
+}
+
+export interface WorkerResultMessage {
+  readonly kind: 'result'
+  readonly result: SweepRunResult
+}
+
+export interface WorkerProgressMessage {
+  readonly kind: 'progress'
+  readonly completed: number // cumulative runs completed in this worker
+}
+
+export interface WorkerDoneMessage {
+  readonly kind: 'done'
+}
+
+export type WorkerOutMessage = WorkerResultMessage | WorkerProgressMessage | WorkerDoneMessage
+
+// --- Conversation generation helper (unwraps Effect) ---
+
+export function generateConversationSync(config: SimulationConfig): readonly Message[] {
+  return Effect.runSync(generateConversation(config))
+}
+
+// --- Metrics extraction from simulation result ---
+
+export function extractMetrics(
+  config: SimulationConfig,
+  messages: readonly Message[],
+): SweepMetrics {
+  const result = runSimulationWithConversation(config, messages)
+  const lastSnapshot = result.snapshots[result.snapshots.length - 1]
+  const externalStoreSize = lastSnapshot ? lastSnapshot.externalStore.totalTokens : 0
+  const totalRetrievalCost =
+    result.summary.totalCost > 0
+      ? lastSnapshot
+        ? lastSnapshot.cumulativeCost.retrievalInput + lastSnapshot.cumulativeCost.retrievalOutput
+        : 0
+      : 0
+
+  return {
+    totalCost: result.summary.totalCost,
+    peakContextSize: result.summary.peakContextSize,
+    compactionEvents: result.summary.compactionEvents,
+    averageCacheHitRate: result.summary.averageCacheHitRate,
+    externalStoreSize,
+    totalRetrievalCost,
+  }
+}

--- a/src/engine/sweep-worker.ts
+++ b/src/engine/sweep-worker.ts
@@ -1,0 +1,42 @@
+import type { WorkerBatch, WorkerResultMessage, WorkerProgressMessage, WorkerDoneMessage } from './sweep-worker-protocol'
+import { extractMetrics } from './sweep-worker-protocol'
+
+const PROGRESS_INTERVAL = 10 // post progress every N runs
+
+function handleBatch(batch: WorkerBatch): void {
+  let completed = 0
+  for (let i = 0; i < batch.runs.length; i++) {
+    const run = batch.runs[i]
+    const metrics = extractMetrics(run.config, run.messages)
+    const resultMsg: WorkerResultMessage = {
+      kind: 'result',
+      result: {
+        index: batch.batchOffset + i,
+        config: run.config,
+        metrics,
+      },
+    }
+    self.postMessage(resultMsg)
+
+    completed++
+    if (completed % PROGRESS_INTERVAL === 0) {
+      const progressMsg: WorkerProgressMessage = {
+        kind: 'progress',
+        completed,
+      }
+      self.postMessage(progressMsg)
+    }
+  }
+
+  // Final progress + done
+  const progressMsg: WorkerProgressMessage = { kind: 'progress', completed }
+  self.postMessage(progressMsg)
+  const doneMsg: WorkerDoneMessage = { kind: 'done' }
+  self.postMessage(doneMsg)
+}
+
+self.onmessage = (e: MessageEvent<WorkerBatch>) => {
+  if (e.data.kind === 'batch') {
+    handleBatch(e.data)
+  }
+}

--- a/src/hooks/useSweep.ts
+++ b/src/hooks/useSweep.ts
@@ -1,0 +1,216 @@
+import { useState, useCallback, useRef } from 'react'
+import type { SimulationConfig } from '@/engine/types'
+import type { SweepConfig, SweepRunResult } from '@/engine/sweep-types'
+import { buildDefaultSweepConfig } from '@/engine/sweep-defaults'
+import { expandSweepConfig, expandParamValues, partitionByShape } from '@/engine/sweep'
+import type { WorkerBatch, WorkerRun, WorkerOutMessage } from '@/engine/sweep-worker-protocol'
+import { generateConversationSync } from '@/engine/sweep-worker-protocol'
+
+const BATCH_SIZE = 50
+const DEFAULT_WORKER_COUNT = 4
+
+export interface UseSweepReturn {
+  sweepConfig: SweepConfig
+  setSweepConfig: React.Dispatch<React.SetStateAction<SweepConfig>>
+  results: SweepRunResult[]
+  progress: number // 0..1
+  isRunning: boolean
+  run: (variableOrder: (keyof SimulationConfig)[]) => void
+  reorder: (variableOrder: (keyof SimulationConfig)[]) => void
+  cancel: () => void
+}
+
+export function useSweep(): UseSweepReturn {
+  const [sweepConfig, setSweepConfig] = useState<SweepConfig>(buildDefaultSweepConfig)
+  const [results, setResults] = useState<SweepRunResult[]>([])
+  const [progress, setProgress] = useState(0)
+  const [isRunning, setIsRunning] = useState(false)
+  const workersRef = useRef<Worker[]>([])
+  const cancelledRef = useRef(false)
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true
+    for (const w of workersRef.current) {
+      w.terminate()
+    }
+    workersRef.current = []
+    setIsRunning(false)
+  }, [])
+
+  const run = useCallback(
+    (variableOrder: (keyof SimulationConfig)[]) => {
+      // Cancel any in-flight sweep
+      for (const w of workersRef.current) {
+        w.terminate()
+      }
+      workersRef.current = []
+      cancelledRef.current = false
+
+      setIsRunning(true)
+      setProgress(0)
+      setResults([])
+
+      // Reorder sweep config keys so variableOrder keys come first
+      const allKeys = Object.keys(sweepConfig) as (keyof SimulationConfig)[]
+      const orderedKeys = [
+        ...variableOrder,
+        ...allKeys.filter((k) => !variableOrder.includes(k)),
+      ]
+      const reorderedConfig = Object.fromEntries(
+        orderedKeys.map((k) => [k, sweepConfig[k]]),
+      ) as SweepConfig
+
+      // Expand to full cartesian product
+      const expanded = expandSweepConfig(reorderedConfig)
+      const totalRuns = expanded.length
+
+      if (totalRuns === 0) {
+        setIsRunning(false)
+        return
+      }
+
+      // Partition by conversation shape and generate conversations
+      const groups = partitionByShape(expanded)
+      const runs: WorkerRun[] = []
+
+      // Build flat run list with pre-generated conversations
+      // Track original indices so results end up in cartesian-product order
+      const configToIndex = new Map<SimulationConfig, number>()
+      expanded.forEach((cfg, i) => configToIndex.set(cfg, i))
+
+      for (const groupConfigs of groups.values()) {
+        // All configs in a group share conversation-shape params — use the first to generate
+        const messages = generateConversationSync(groupConfigs[0])
+        for (const config of groupConfigs) {
+          runs.push({ config, messages: [...messages] })
+        }
+      }
+
+      // Sort runs back into cartesian-product index order
+      runs.sort((a, b) => (configToIndex.get(a.config) ?? 0) - (configToIndex.get(b.config) ?? 0))
+
+      // Distribute into batches
+      const batches: WorkerBatch[] = []
+      for (let i = 0; i < runs.length; i += BATCH_SIZE) {
+        batches.push({
+          kind: 'batch',
+          runs: runs.slice(i, i + BATCH_SIZE),
+          batchOffset: i,
+        })
+      }
+
+      // Spawn workers and distribute batches round-robin
+      const workerCount = Math.min(
+        navigator.hardwareConcurrency || DEFAULT_WORKER_COUNT,
+        batches.length,
+      )
+
+      const collectedResults: SweepRunResult[] = new Array(totalRuns)
+      let resultsReceived = 0
+      let workersDone = 0
+
+      const workers: Worker[] = []
+      // Group batches per worker for round-robin distribution
+      const workerBatches: WorkerBatch[][] = Array.from({ length: workerCount }, () => [])
+      batches.forEach((batch, i) => {
+        workerBatches[i % workerCount].push(batch)
+      })
+
+      for (let w = 0; w < workerCount; w++) {
+        const worker = new Worker(
+          new URL('../engine/sweep-worker.ts', import.meta.url),
+          { type: 'module' },
+        )
+        workers.push(worker)
+
+        let batchIndex = 0
+
+        worker.onmessage = (e: MessageEvent<WorkerOutMessage>) => {
+          if (cancelledRef.current) return
+
+          const msg = e.data
+          if (msg.kind === 'result') {
+            collectedResults[msg.result.index] = msg.result
+            resultsReceived++
+            setProgress(Math.min(resultsReceived / totalRuns, 1))
+          } else if (msg.kind === 'done') {
+            // Send next batch to this worker
+            batchIndex++
+            if (batchIndex < workerBatches[w].length) {
+              worker.postMessage(workerBatches[w][batchIndex])
+            } else {
+              workersDone++
+              worker.terminate()
+              if (workersDone === workerCount) {
+                workersRef.current = []
+                if (!cancelledRef.current) {
+                  setResults([...collectedResults])
+                  setProgress(1)
+                  setIsRunning(false)
+                }
+              }
+            }
+          }
+        }
+
+        // Start the first batch for this worker
+        if (workerBatches[w].length > 0) {
+          worker.postMessage(workerBatches[w][0])
+        }
+      }
+
+      workersRef.current = workers
+    },
+    [sweepConfig],
+  )
+
+  const reorder = useCallback(
+    (variableOrder: (keyof SimulationConfig)[]) => {
+      if (results.length === 0) return
+
+      // Build the key order: variableOrder first, then remaining keys
+      const allKeys = Object.keys(sweepConfig) as (keyof SimulationConfig)[]
+      const orderedKeys = [
+        ...variableOrder,
+        ...allKeys.filter((k) => !variableOrder.includes(k)),
+      ]
+
+      // For each key, get the expanded values in order so we can map config values to indices
+      const paramArrays = orderedKeys.map((key) => ({
+        key,
+        values: expandParamValues(key, sweepConfig[key]),
+      }))
+
+      // Compute a sort key for each result: its position in the new cartesian product order
+      const sortKey = (r: SweepRunResult): number => {
+        let index = 0
+        for (const { key, values } of paramArrays) {
+          const configValue = r.config[key]
+          // Find closest value index (handles floating point from log scale)
+          let valueIndex = values.findIndex((v) => v === configValue)
+          if (valueIndex === -1) {
+            // Fallback: find closest numeric match
+            valueIndex = values.reduce<number>(
+              (best, v, i) =>
+                Math.abs(Number(v) - Number(configValue)) <
+                Math.abs(Number(values[best] as number) - Number(configValue))
+                  ? i
+                  : best,
+              0,
+            )
+          }
+          index = index * values.length + valueIndex
+        }
+        return index
+      }
+
+      const sorted = [...results]
+        .sort((a, b) => sortKey(a) - sortKey(b))
+        .map((r, i) => ({ ...r, index: i }))
+      setResults(sorted)
+    },
+    [results, sweepConfig],
+  )
+
+  return { sweepConfig, setSweepConfig, results, progress, isRunning, run, reorder, cancel }
+}


### PR DESCRIPTION
## Summary

- **sweep-worker.ts**: Web worker entry point that receives batches of `{ config, messages }` pairs, runs each through `runSimulationWithConversation`, and posts back `SweepRunResult` objects with progress updates. Batch size of 50.
- **sweep-worker-protocol.ts**: Shared types and functions (message protocol, `extractMetrics`, `generateConversationSync`) split out so tests can import without triggering `self.onmessage` in Node.
- **useSweep hook**: Manages sweep config state, expands the cartesian product, partitions by conversation shape for conversation reuse, distributes work across N workers (`navigator.hardwareConcurrency` or 4), tracks progress per result received, supports cancel via worker termination, and includes a `reorder()` function that re-sorts existing results by a new variable order without re-running simulations.
- **ExplorerTab**: Replaced all mock data generation with the real `useSweep` hook. Heat bar shows real simulation results, progress bar is live, cancel works.

Closes #48

## Test plan

- [x] Type check passes (`tsc --noEmit`)
- [x] Lint passes (`npm run lint`) — no new warnings
- [x] All 177 tests pass (`npm test`) — 5 new sweep worker tests
- [x] Production build succeeds (`npm run build`) — worker correctly bundled as separate chunk
- [x] Manual: configure a small sweep in Explorer, click Run, verify real results appear
- [x] Manual: verify progress bar updates during sweep execution
- [x] Manual: verify cancel terminates workers mid-sweep
- [x] Manual: verify variable reorder re-sorts without re-running

🤖 Generated with [Claude Code](https://claude.com/claude-code)