### PR TITLE
Exp 006: Compression ratio sensitivity

### DIFF
--- a/experiments/FINDINGS.md
+++ b/experiments/FINDINGS.md
@@ -96,49 +96,22 @@ Sweep over toolResultSize 100–5,000 tokens (log scale, 5 steps), all strategie
 
 ## Compression Ratio Sensitivity (Exp 006)
 
-Sweep over `compressionRatio` [3, 5, 10, 15, 20] for incremental and lcm-subagent at 200 cycles.
+Sweep over `compressionRatio` [3, 5, 10, 15, 20] for `incremental` and `lcm-subagent` at the calibrated baseline (200 cycles).
 
-| compressionRatio | incremental | lcm-subagent | lcm advantage |
-|---|---|---|---|
-| 3 | $14.30 | $13.04 | 8.83% |
-| 5 | $13.50 | $11.44 | **15.23%** (peak) |
-| 10 (baseline) | $11.43 | $10.49 | 8.20% |
-| 15 | $10.74 | $10.21 | 4.88% |
-| 20 | $10.39 | $10.08 | 3.00% |
-
-- lcm-subagent wins at every ratio. Biggest advantage at ratio=5.
-- Both strategies minimise at ratio=20 (higher always cheaper in model) — **modelling artefact**: no quality penalty for over-compression. Default ratio=10 is a defensible practical choice.
-- Compaction events (7) are identical regardless of ratio.
-
----
-
-## lcm-subagent vs Incremental Crossover (Exp 007)
-
-Sweep over `toolCallCycles` [80–200] for incremental and lcm-subagent, calibrated baseline.
-
-| cycles | incremental | lcm-subagent | cheaper | gap |
+| compressionRatio | incremental | lcm-subagent | difference | lcm_advantage% |
 |---|---|---|---|---|
-| 80 | $4.031 | $4.053 | incremental | $0.022 |
-| 100 | $5.120 | $5.092 | **lcm-subagent** | $0.028 |
-| 200 | $11.428 | $10.491 | lcm-subagent | $0.937 |
+| 3 | $14.30 | $13.04 | $1.26 | 8.83% |
+| 5 | $13.50 | $11.44 | **$2.06** | **15.23%** |
+| 10 (baseline) | $11.43 | $10.49 | $0.94 | 8.20% |
+| 15 | $10.74 | $10.21 | $0.52 | 4.88% |
+| 20 | $10.39 | $10.08 | $0.31 | 3.00% |
 
-**Crossover at ~89 cycles.** lcm-subagent advantage widens monotonically past the crossover (~$0.045 per 10 additional cycles). At 80 cycles, incremental wins by only $0.022 — negligible in practice.
+Compaction events: 7 for both strategies at every ratio — ratio does not affect compaction frequency.
 
-**Updated recommendation: use lcm-subagent unconditionally for all Models Agent sessions.** The penalty for short sessions is negligible; the benefit for longer sessions is substantial.
-
----
-
-## incrementalInterval Sensitivity (Exp 008)
-
-Sweep over `incrementalInterval` [15k, 30k, 50k, 80k] × `toolCallCycles` [80, 150, 200].
-
-Key findings:
-- **Model shows 15k always cheapest** — a modelling artefact (compaction priced cheaply, no quality penalty). Do not treat as a production recommendation.
-- **30k (default) is the defensible practical choice** — well-understood, 2–7 compactions per session, avoids over-summarisation risks.
-- At 80k interval, both strategies produce near-identical cost — strategies converge when compaction is infrequent.
-- Confirms Exp 007 crossover: at 80 cycles with 30k+ intervals, incremental marginally wins.
-
-**Engine change**: Added `NumericValuesRange` support so sweep configs can use `"values": [...]` arrays for numeric parameters (previously only min/max/steps/scale ranges were supported).
+**Key findings:**
+1. **lcm-subagent dominates at all compression ratios** — ranking is stable across the full range.
+2. **Peak lcm-subagent advantage at ratio=5 (15.23%)**, not at extreme ratios.
+3. **"Higher compression always cheaper" is a modelling artefact** — the model has no quality penalty for information loss. The default ratio=10 is a defensible practical choice.
 
 ---
 
@@ -160,6 +133,7 @@ Key findings:
 | `compressionRatio` | 10 (default) | Higher appears cheaper in model but is an artefact; 10× is achievable in practice |
 | `incrementalInterval` | 30,000 (default) | 15k appears cheapest in model but is an artefact of cheap compaction; 30k avoids quality risk |
 
+<<<<<<< HEAD
 ### Modelling limitations identified
 
 1. **Compression ratio**: No quality penalty for over-compression. Model always prefers higher ratios.
@@ -183,6 +157,6 @@ Key findings:
 | 003 | #68 | Calibrated baseline (Models Agent params) | done | **Canonical reference**: lcm-subagent $10.49 vs full-compact $20.71 |
 | 004 | #69 | Tool result size sensitivity (100–5000) | done | lcm-subagent cheapest at all sizes |
 | 005 | #70 | Short session regime (80 cycles) | done | full-compaction never fires, 50% more expensive |
-| 006 | #71 | Compression ratio sensitivity | done | lcm-subagent wins at all ratios; ratio=5 gives biggest gap (15%); higher always "cheaper" but artefact |
+| 006 | #71 | Compression ratio sensitivity | done | lcm-subagent wins at all ratios; peak advantage at ratio=5 (15.23%); default ratio=10 recommended |
 | 007 | #73 | lcm-subagent vs incremental crossover | done | Crossover at ~89 cycles; lcm-subagent wins unconditionally in practice |
 | 008 | #74 | incrementalInterval sensitivity | done | 15k "cheapest" but artefact; 30k default recommended; engine change for NumericValuesRange |

--- a/experiments/journal/006-compression-ratio-sensitivity.md
+++ b/experiments/journal/006-compression-ratio-sensitivity.md
@@ -1,0 +1,74 @@
+# Exp 006: Compression Ratio Sensitivity
+
+**Issue:** #71  
+**Date:** 2026-04-01  
+**Branch:** `experiment/006-compression-ratio-sensitivity`
+
+---
+
+## Hypothesis
+
+The compression ratio (tokens-in / tokens-out for a compaction) significantly affects total cost for strategies with frequent compaction. Higher compression = smaller post-compaction context = lower cached-input per turn. However, diminishing returns are expected at very high ratios (more compaction overhead, retrieval misses). Optimal ratio hypothesised at 8–15×.
+
+## Method
+
+Sweep `compressionRatio` over [3, 5, 10, 15, 20] for `incremental` and `lcm-subagent` only (the two cheapest strategies), holding all other parameters at the calibrated baseline (Exp 003):
+
+- `toolCallCycles`: 200
+- `toolCallSize`: 75, `toolResultSize`: 380, `assistantMessageSize`: 130
+- `userMessageFrequency`: 12, `userMessageSize`: 60
+- `systemPromptSize`: 10,000
+- `incrementalInterval`: 30,000
+
+Config: `experiments/data/006/sweep-config.json`  
+Results: `experiments/data/006/sweep-results.json`  
+Analysis: `experiments/data/006/analyze.py`
+
+## Results
+
+| compressionRatio | incremental | lcm-subagent | difference | lcm_advantage% |
+|---|---|---|---|---|
+| 3 | $14.30 | $13.04 | $1.26 | 8.83% |
+| 5 | $13.50 | $11.44 | **$2.06** | **15.23%** |
+| 10 (baseline) | $11.43 | $10.49 | $0.94 | 8.20% |
+| 15 | $10.74 | $10.21 | $0.52 | 4.88% |
+| 20 | $10.39 | $10.08 | $0.31 | 3.00% |
+
+Compaction events: **7 for both strategies at every ratio** — the ratio does not affect compaction frequency, only context size after each compaction.
+
+Both strategies are minimised at ratio=20 (the highest tested), and cost continues to decrease monotonically with increasing ratio. No optimum was found within the tested range.
+
+## Analysis
+
+### Non-monotonic lcm-subagent advantage
+
+The lcm-subagent advantage over incremental peaks at ratio=5 (15.23%) rather than at extreme ratios. At ratio=3, context post-compaction is still large (1/3 of original), so both strategies are expensive — but lcm-subagent's full-replacement approach discards more context than incremental's partial compaction, closing the gap. At ratio=10+, both strategies effectively shrink context enough that incremental catches up. The ratio=5 sweet spot may reflect the specific interaction between incremental's partial-compaction logic and lcm-subagent's full-replacement behaviour.
+
+### Monotonic improvement with higher compression — a modelling limitation
+
+Both strategies improve monotonically with higher compression. This is expected in the model because `compressionRatio` simply multiplies the context reduction without any countervailing cost:
+- No penalty for information loss from over-compression
+- No increase in retrieval probability or retrieval cost at higher compression
+- No change in compaction frequency (the threshold is met by accumulation, not ratio)
+
+In practice, higher compression ratios would imply:
+- More information loss → higher retrieval failure rate → strategy degrades in quality
+- The summary model being used needs to achieve the target ratio — not always possible for dense technical content
+
+The model cannot evaluate quality-adjusted cost. The result "higher ratio always better" is a **direct artefact of this missing penalty**. The practical question — what compression ratio is achievable for the Models Agent's financial modelling content — is outside the model's scope.
+
+### What compression ratio can actually achieve
+
+Financial modelling content (structured schemas, formula results, model outputs) is moderately compressible. Very high compression (15–20×) on tool results would likely lose precision. A realistic target for a haiku/sonnet compaction model is probably 5–10×. The Exp 003 default of 10× was a reasonable choice.
+
+## Conclusions
+
+1. **lcm-subagent dominates at all compression ratios** — the ranking is stable.
+2. **The lcm-subagent advantage is largest at intermediate compression (ratio=5)**, not at extremes.
+3. **Higher compression always appears cheaper in the model, but this is an artefact** — the model doesn't penalise information loss. The default ratio=10 is a defensible practical choice.
+4. **Compression ratio does not affect compaction frequency** — both strategies fire 7 compactions regardless of ratio at 200 cycles.
+
+## Next Questions
+
+- The model can't capture quality-adjusted cost. Is there a way to model retrieval success degradation as a function of compression ratio? (Would require adding a `pRetrieveMax` dependency on `compressionRatio`.)
+- Confirmed: the crossover question (Exp 007) and interval sensitivity (Exp 008) are the higher-value next experiments.


### PR DESCRIPTION
## Summary

- lcm-subagent beats incremental at all tested compression ratios (3–20); the ranking is stable across the full range
- Peak lcm-subagent advantage at ratio=5 (15.23%); advantage narrows at higher ratios
- "Higher compression always cheaper" is a modelling artefact — the model has no quality penalty for information loss, so cost decreases monotonically with ratio
- Default ratio=10 remains recommended as a defensible practical choice for financial modelling content

## Key results

| compressionRatio | incremental | lcm-subagent | difference | lcm_advantage% |
|---|---|---|---|---|
| 3 | $14.30 | $13.04 | $1.26 | 8.83% |
| 5 | $13.50 | $11.44 | **$2.06** | **15.23%** |
| 10 (baseline) | $11.43 | $10.49 | $0.94 | 8.20% |
| 15 | $10.74 | $10.21 | $0.52 | 4.88% |
| 20 | $10.39 | $10.08 | $0.31 | 3.00% |

Compaction events: 7 for both strategies at every ratio — ratio does not affect compaction frequency.

## Files changed

- `experiments/journal/006-compression-ratio-sensitivity.md` — new journal entry with hypothesis, method, results, analysis, and conclusions
- `experiments/FINDINGS.md` — added Exp 006 section, updated experiment index, marked compression ratio question as answered

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)