### PR TITLE
Exp 008: incrementalInterval sensitivity + engine NumericValuesRange

### DIFF
--- a/experiments/FINDINGS.md
+++ b/experiments/FINDINGS.md
@@ -115,11 +115,57 @@ Compaction events: 7 for both strategies at every ratio — ratio does not affec
 
 ---
 
+## lcm-subagent vs Incremental Crossover (Exp 007)
+
+Sweep over `toolCallCycles` [80–200] for `incremental` and `lcm-subagent`, calibrated baseline.
+
+| toolCallCycles | incremental | lcm-subagent | cheaper | gap |
+|---|---|---|---|---|
+| 80 | $4.031 | $4.053 | incremental | $0.022 |
+| 100 | $5.120 | $5.092 | **lcm-subagent** | $0.028 |
+| 120 | $6.302 | $6.173 | lcm-subagent | $0.129 |
+| 140 | $7.602 | $7.348 | lcm-subagent | $0.253 |
+| 160 | $8.766 | $8.347 | lcm-subagent | $0.419 |
+| 180 | $10.048 | $9.400 | lcm-subagent | $0.648 |
+| 200 | $11.428 | $10.491 | lcm-subagent | $0.937 |
+
+**Crossover at ~89 cycles** (between 80 and 100). lcm-subagent advantage widens monotonically past the crossover (~$0.045 per 10 additional cycles).
+
+**Updated recommendation: use lcm-subagent unconditionally** for all Models Agent sessions. The penalty at short sessions ($0.022 at 80 cycles) is negligible; the benefit at 200 cycles is $0.94.
+
+---
+
+## incrementalInterval Sensitivity (Exp 008)
+
+Sweep over `incrementalInterval` [15k, 30k, 50k, 80k] × `toolCallCycles` [80, 150, 200] for `incremental` and `lcm-subagent`.
+
+| cycles | interval | incremental | lcm-subagent | cheaper |
+|---|---|---|---|---|
+| 80 | 15,000 | $3.542 | $3.456 | lcm-subagent |
+| 80 | 30,000 | $4.031 | $4.053 | incremental |
+| 80 | 50,000 | $4.583 | $4.659 | incremental |
+| 80 | 80,000 | $5.692 | $5.692 | tie |
+| 150 | 15,000 | $7.198 | $6.602 | lcm-subagent |
+| 150 | 80,000 | $11.510 | $11.649 | incremental |
+| 200 | 15,000 | $10.147 | $8.837 | lcm-subagent |
+| 200 | 30,000 | $11.428 | $10.491 | lcm-subagent |
+| 200 | 80,000 | $15.390 | $15.300 | lcm-subagent |
+
+**Key findings:**
+1. **Model always prefers interval=15k** — a modelling artefact (cheap compaction, no quality penalty). Do not treat as a production recommendation.
+2. **30k (default) is the defensible practical choice** — avoids over-summarisation risks, 2–7 compactions per session.
+3. **At 80k interval, strategies converge** — with only 1–2 compactions both strategies behave nearly identically.
+4. Confirms Exp 007 crossover: incremental wins at 80 cycles with 30k+ intervals; lcm-subagent wins at 15k even for short sessions.
+
+**Engine change (Exp 008):** Added `NumericValuesRange` to `sweep-types.ts` and handler in `sweep.ts` so numeric sweep params support `"values": [...]` arrays in addition to `{min, max, steps, scale}` ranges.
+
+---
+
 ## Cross-Experiment Conclusions
 
 ### Strategy recommendation for Models Agent
 
-**Use `lcm-subagent` unconditionally.** It is the cheapest strategy for sessions ≥ 90 cycles, and the cost penalty at shorter sessions is negligible ($0.022). Avoid `full-compaction` in all cases.
+**Use `lcm-subagent` unconditionally.** It is the cheapest strategy for sessions ≥ 90 cycles, and the penalty at shorter sessions is negligible ($0.022). Avoid `full-compaction` in all cases.
 
 | Session length | Recommended strategy | Rationale |
 |---|---|---|
@@ -131,20 +177,19 @@ Compaction events: 7 for both strategies at every ratio — ratio does not affec
 | Parameter | Recommended value | Notes |
 |---|---|---|
 | `compressionRatio` | 10 (default) | Higher appears cheaper in model but is an artefact; 10× is achievable in practice |
-| `incrementalInterval` | 30,000 (default) | 15k appears cheapest in model but is an artefact of cheap compaction; 30k avoids quality risk |
+| `incrementalInterval` | 30,000 (default) | 15k appears cheapest but is a model artefact; 30k avoids over-summarisation risk |
 
-<<<<<<< HEAD
 ### Modelling limitations identified
 
 1. **Compression ratio**: No quality penalty for over-compression. Model always prefers higher ratios.
 2. **Compaction frequency**: No latency cost or quality-degradation cost for over-compaction. Model always prefers shorter intervals.
-3. **Retrieval quality**: `pRetrieveMax` is fixed; should degrade with higher compression or more distant history.
+3. **Retrieval quality**: `pRetrieveMax` is fixed; in reality retrieval should degrade with higher compression or more distant history.
 
 ### Open questions for future phases
 
-- `pRetrieveMax` sensitivity: how sensitive is lcm-subagent's advantage to retrieval success rate?
-- Crossover shift under different compression ratios or tool result sizes
-- Latency modelling: compaction frequency trade-offs when wall-clock time matters
+- **`pRetrieveMax` sensitivity**: How sensitive is lcm-subagent's advantage to retrieval success rate? What happens to the recommendation if retrieval degrades?
+- **Crossover shift**: How does the ~89 cycle crossover shift under different compression ratios or tool result sizes?
+- **Latency modelling**: Can compaction frequency trade-offs be evaluated when wall-clock time matters?
 
 ---
 
@@ -157,6 +202,6 @@ Compaction events: 7 for both strategies at every ratio — ratio does not affec
 | 003 | #68 | Calibrated baseline (Models Agent params) | done | **Canonical reference**: lcm-subagent $10.49 vs full-compact $20.71 |
 | 004 | #69 | Tool result size sensitivity (100–5000) | done | lcm-subagent cheapest at all sizes |
 | 005 | #70 | Short session regime (80 cycles) | done | full-compaction never fires, 50% more expensive |
-| 006 | #71 | Compression ratio sensitivity | done | lcm-subagent wins at all ratios; peak advantage at ratio=5 (15.23%); default ratio=10 recommended |
+| 006 | #71 | Compression ratio sensitivity | done | lcm-subagent wins at all ratios; peak at ratio=5 (15.23%); default ratio=10 recommended |
 | 007 | #73 | lcm-subagent vs incremental crossover | done | Crossover at ~89 cycles; lcm-subagent wins unconditionally in practice |
-| 008 | #74 | incrementalInterval sensitivity | done | 15k "cheapest" but artefact; 30k default recommended; engine change for NumericValuesRange |
+| 008 | #74 | incrementalInterval sensitivity | done | 15k "cheapest" is a model artefact; 30k default recommended; engine: NumericValuesRange |

--- a/experiments/journal/008-incremental-interval-sensitivity.md
+++ b/experiments/journal/008-incremental-interval-sensitivity.md
@@ -1,0 +1,121 @@
+# Exp 008: incrementalInterval Sensitivity — Impact on Short and Medium Sessions
+
+**Issue:** #74  
+**Date:** 2026-04-01  
+**Branch:** `experiment/008-incremental-interval-sensitivity`
+
+---
+
+## Hypothesis
+
+The default `incrementalInterval` (30k tokens) fires compaction twice in an 80-cycle session. Reducing the interval causes more compactions (more overhead) but smaller peak context. Increasing it delays compaction, allowing more cache hits initially but larger context later. The optimal value depends on session length.
+
+Expected: shorter interval preferred for long sessions (more frequent context reduction), longer interval preferred for short sessions (fewer compaction events = less overhead when context stays manageable).
+
+## Engine Change
+
+This experiment required adding support for `values: number[]` arrays in numeric sweep parameters. Previously, only `{min, max, steps, scale}` ranges were supported for numeric params. The engine was extended:
+
+- `src/engine/sweep-types.ts`: Added `NumericValuesRange` interface
+- `src/engine/sweep.ts`: Added handler in `expandParamValues` to detect and expand explicit values arrays
+
+This is a general capability improvement — any numeric parameter can now use explicit discrete values in sweep configs. See commit `[engine] Add NumericValuesRange support for explicit values in numeric sweep params`.
+
+## Method
+
+Sweep `incrementalInterval` over [15000, 30000, 50000, 80000] × `toolCallCycles` [80, 150, 200] for `incremental` and `lcm-subagent`, calibrated baseline.
+
+Config: `experiments/data/008/sweep-config.json`  
+Results: `experiments/data/008/sweep-results.json`  
+Analysis: `experiments/data/008/analyze.py`
+
+## Results
+
+### Full cost table (incremental vs lcm-subagent)
+
+| cycles | interval | incremental | lcm-subagent | cheaper |
+|---|---|---|---|---|
+| 80 | 15,000 | $3.542 | $3.456 | lcm-subagent |
+| 80 | 30,000 | $4.031 | $4.053 | incremental |
+| 80 | 50,000 | $4.583 | $4.659 | incremental |
+| 80 | 80,000 | $5.692 | $5.692 | tie |
+| 150 | 15,000 | $7.198 | $6.602 | lcm-subagent |
+| 150 | 30,000 | $8.129 | $7.786 | lcm-subagent |
+| 150 | 50,000 | $9.388 | $9.301 | lcm-subagent |
+| 150 | 80,000 | $11.510 | $11.649 | incremental |
+| 200 | 15,000 | $10.147 | $8.837 | lcm-subagent |
+| 200 | 30,000 | $11.428 | $10.491 | lcm-subagent |
+| 200 | 50,000 | $13.074 | $12.582 | lcm-subagent |
+| 200 | 80,000 | $15.390 | $15.300 | lcm-subagent |
+
+### Best interval per strategy
+
+| cycles | strategy | best interval | best cost |
+|---|---|---|---|
+| 80 | incremental | 15,000 | $3.542 |
+| 80 | lcm-subagent | 15,000 | $3.456 |
+| 150 | incremental | 15,000 | $7.198 |
+| 150 | lcm-subagent | 15,000 | $6.602 |
+| 200 | incremental | 15,000 | $10.147 |
+| 200 | lcm-subagent | 15,000 | $8.837 |
+
+### Compaction events
+
+| cycles | interval | compactions |
+|---|---|---|
+| 80 | 15,000 | 5 |
+| 80 | 30,000 | 2 |
+| 80 | 50,000 | 1 |
+| 80 | 80,000 | 1 |
+| 150 | 15,000 | 10 |
+| 150 | 30,000 | 5 |
+| 150 | 50,000 | 3 |
+| 150 | 80,000 | 2 |
+| 200 | 15,000 | 14 |
+| 200 | 30,000 | 7 |
+| 200 | 50,000 | 4 |
+| 200 | 80,000 | 2 |
+
+Both strategies fire identical compaction counts for any given (cycles, interval) pair.
+
+## Analysis
+
+### The "smaller interval always wins" result — and its limitations
+
+The model shows shorter intervals are always cheaper: 15k beats 30k beats 50k beats 80k at every session length. The mechanism is: more frequent compaction → smaller average context size → lower per-turn input token cost. Since the model prices compaction cheaply ($0.80/M input, $4/M output), the context-reduction benefit always outweighs the compaction overhead.
+
+**This result is a probable modelling artefact.** In practice, more frequent compaction has costs the model cannot represent:
+1. **Latency**: Each compaction adds a round-trip to a smaller LLM. At 14 compactions in a 200-cycle session, this adds meaningful wall-clock time.
+2. **Quality degradation**: Compacting every 15k tokens means summaries of summaries accumulate quickly. The incremental meta-compaction path (compacting accumulated summaries when they exceed `summaryAccumulationThreshold`) doesn't capture the quality loss from over-summarisation.
+3. **The 15k interval fires 14 compactions at 200 cycles**: This is one compaction every ~14 cycles (~25 tool calls), which is quite aggressive.
+
+The practical recommendation is **not** to set `incrementalInterval` to 15k without validating compaction quality. The 30k default is more defensible.
+
+### The interesting finding: incremental wins at 80 cycles with intervals ≥ 30k
+
+At 80 cycles with intervals of 30k and 50k, incremental is cheaper than lcm-subagent. This is consistent with the Exp 007 crossover finding: below ~89 cycles, lcm-subagent's retrieval overhead tips the balance. At interval=15k with 80 cycles, the additional compactions change the picture (5 compactions vs 2), giving lcm-subagent enough context-reduction benefit to win.
+
+### The 80k tie
+
+At 80k interval, both strategies produce essentially the same cost for any session length. With only 1–2 compactions regardless of length, the strategies converge to near-identical behaviour.
+
+### Crossover in the interval dimension
+
+At 150 cycles, lcm-subagent wins at intervals ≤ 50k but loses at 80k. The longer the interval, the less context compression occurs — and lcm-subagent's retrieval overhead dominates when compaction is infrequent. This is a second dimension of the crossover: beyond a session length threshold *and* below an interval threshold, lcm-subagent wins.
+
+## Conclusions
+
+1. **The model always prefers shorter intervals** — an artefact of cheap compaction cost with no quality penalty. Do not interpret this as a recommendation to set `incrementalInterval` to 15k in production.
+2. **30k (the default) is a reasonable practical choice**: well-understood behaviour, 2–7 compactions across typical session lengths, avoids quality-degradation risks.
+3. **lcm-subagent remains the preferred strategy** at standard interval settings for sessions ≥ 100 cycles. The result confirms Exp 007.
+4. **Both strategies converge at large intervals (80k)** — with only 1–2 compactions, the strategies are nearly equivalent.
+5. **Engine change**: Added `NumericValuesRange` to support explicit `values` arrays for numeric sweep parameters — a general capability improvement now available for all future sweeps.
+
+## Modelling Gap Identified
+
+The simulation cannot capture latency-vs-cost trade-offs for compaction frequency. A future engine enhancement could add a `compactionLatencyMs` parameter and a `totalLatency` metric, allowing the researcher to evaluate cost-latency Pareto frontiers.
+
+## Next Questions
+
+- How does the crossover shape (both session length and interval dimensions) change with different `toolResultSize` values?
+- Phase 2: explore `pRetrieveMax` sensitivity — how sensitive is lcm-subagent's advantage to retrieval success rate?

--- a/src/engine/sweep-types.ts
+++ b/src/engine/sweep-types.ts
@@ -22,6 +22,11 @@ export interface StrategySweepRange {
   readonly values: StrategyType[]
 }
 
+export interface NumericValuesRange {
+  readonly kind: 'swept'
+  readonly values: number[]
+}
+
 export interface BooleanSweepRange {
   readonly kind: 'swept'
 }
@@ -31,6 +36,7 @@ export type SweepParameterDef =
   | FixedValue<StrategyType>
   | FixedValue<boolean>
   | NumericSweepRange
+  | NumericValuesRange
   | StrategySweepRange
   | BooleanSweepRange
 

--- a/src/engine/sweep.ts
+++ b/src/engine/sweep.ts
@@ -42,6 +42,10 @@ export function expandParamValues(key: keyof SimulationConfig, def: SweepParamet
   if (meta.paramKind === 'boolean') {
     return [false, true]
   }
+  // Numeric: explicit values array
+  if ('values' in def) {
+    return (def as { values: number[] }).values
+  }
   const numDef = def as NumericSweepRange
   return numDef.scale === 'log'
     ? generateLogValues(numDef.min, numDef.max, numDef.steps)


### PR DESCRIPTION
## Summary

- Sweeps `incrementalInterval` [15k, 30k, 50k, 80k] × `toolCallCycles` [80, 150, 200] for `incremental` and `lcm-subagent` at the calibrated baseline
- Model shows 15k is always cheapest — identified as a **modelling artefact** (cheap compaction, no quality penalty); **30k default is the recommended practical setting**
- Strategies converge to near-identical cost at 80k interval (only 1–2 compactions regardless of session length)
- Confirms the Exp 007 crossover: incremental marginally wins at 80 cycles with 30k+ intervals; lcm-subagent wins unconditionally when using shorter intervals or longer sessions

## Engine Change

Added `NumericValuesRange` to support explicit `values: number[]` arrays in numeric sweep parameters (`sweep-types.ts` + handler in `sweep.ts`). Previously only `{min, max, steps, scale}` ranges were supported for numeric params — this was discovered as a gap when writing the sweep config for this experiment.

This is a general capability improvement; any numeric parameter can now use discrete value lists in sweep configs.

## Deliverables

- `experiments/journal/008-incremental-interval-sensitivity.md`
- `experiments/data/008/sweep-config.json`, `sweep-results.json`, `analyze.py`, `analysis-output.txt`
- `experiments/FINDINGS.md` — adds Exp 006, 007, 008 sections and updated cross-experiment conclusions (comprehensive update since upstream PRs #82/#83 haven't merged yet)
- `src/engine/sweep-types.ts`, `src/engine/sweep.ts` — NumericValuesRange engine change

Closes #74