### PR TITLE
[engine] Add cacheReliability parameter

### DIFF
--- a/src/components/controls/ParameterPanel.tsx
+++ b/src/components/controls/ParameterPanel.tsx
@@ -374,6 +374,7 @@ export function ParameterPanel({ config, onUpdate }: ParameterPanelProps) {
             {slider('contextWindow')}
             {slider('compactionThreshold')}
             {slider('compressionRatio')}
+            {numberInput('cacheReliability')}
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/src/engine/__tests__/simulation.test.ts
+++ b/src/engine/__tests__/simulation.test.ts
@@ -664,6 +664,62 @@ describe('runSimulation', () => {
     })
   })
 
+  describe('cacheReliability', () => {
+    const baseConfig: SimulationConfig = {
+      ...DEFAULT_CONFIG,
+      toolCallCycles: 10,
+      toolCallSize: 200,
+      toolResultSize: 2_000,
+      assistantMessageSize: 300,
+      reasoningOutputSize: 0,
+      userMessageFrequency: 100,
+      userMessageSize: 200,
+      systemPromptSize: 4_000,
+      contextWindow: 200_000,
+      compactionThreshold: 0.99,
+      compressionRatio: 10,
+    }
+
+    it('cacheReliability=1.0 produces identical results to omitting it', () => {
+      const result = run({ ...baseConfig, cacheReliability: 1.0 })
+      const resultDefault = run(baseConfig)
+      expect(result.summary.totalCost).toBe(resultDefault.summary.totalCost)
+      expect(result.summary.averageCacheHitRate).toBe(resultDefault.summary.averageCacheHitRate)
+    })
+
+    it('cacheReliability=0.0 produces zero cache hits', () => {
+      const result = run({ ...baseConfig, cacheReliability: 0.0 })
+      const llmSteps = result.snapshots.filter(
+        (s) => s.message.type === 'assistant' || s.message.type === 'reasoning',
+      )
+      // After the first LLM step (which has no previous context), all should have 0 hits
+      for (let i = 1; i < llmSteps.length; i++) {
+        expect(llmSteps[i].cache.cacheHitTokens).toBe(0)
+      }
+      expect(result.summary.averageCacheHitRate).toBe(0)
+    })
+
+    it('lower cacheReliability produces higher total cost', () => {
+      const perfectCache = run({ ...baseConfig, cacheReliability: 1.0 })
+      const degradedCache = run({ ...baseConfig, cacheReliability: 0.5 })
+      expect(degradedCache.summary.totalCost).toBeGreaterThan(perfectCache.summary.totalCost)
+    })
+
+    it('lower cacheReliability produces lower average cache hit rate', () => {
+      const perfectCache = run({ ...baseConfig, cacheReliability: 1.0 })
+      const degradedCache = run({ ...baseConfig, cacheReliability: 0.5 })
+      expect(degradedCache.summary.averageCacheHitRate).toBeLessThan(
+        perfectCache.summary.averageCacheHitRate,
+      )
+    })
+
+    it('results are deterministic for the same cacheReliability value', () => {
+      const result1 = run({ ...baseConfig, cacheReliability: 0.7 })
+      const result2 = run({ ...baseConfig, cacheReliability: 0.7 })
+      expect(result1.summary.totalCost).toBe(result2.summary.totalCost)
+    })
+  })
+
   describe('runSimulationWithConversation', () => {
     it('produces identical results to runSimulation for the same config', () => {
       const config: SimulationConfig = {

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -247,11 +247,28 @@ export function calculateCache(
     return state
   }
 
-  const cache = prefixCacheModel.calculate(
+  let cache = prefixCacheModel.calculate(
     state.previousContext,
     state.context,
     config,
   )
+
+  // Probabilistic cache degradation: on each LLM call step, even if the
+  // prefix is stable, there's a (1 - cacheReliability) chance of a full miss.
+  // At the default cacheReliability=1.0 this branch is never entered and the
+  // RNG sequence is unchanged, preserving backwards compatibility.
+  if (config.cacheReliability < 1.0 && cache.cacheHitTokens > 0) {
+    const roll = state.rng()
+    if (roll >= config.cacheReliability) {
+      cache = {
+        cachedPrefixTokens: 0,
+        cacheHitTokens: 0,
+        cacheWriteTokens: cache.cacheWriteTokens,
+        uncachedTokens: cache.cacheHitTokens + cache.uncachedTokens,
+        hitRate: 0,
+      }
+    }
+  }
 
   return {
     ...state,

--- a/src/engine/sweep-defaults.ts
+++ b/src/engine/sweep-defaults.ts
@@ -217,6 +217,22 @@ export const PARAM_META: ParamMetaRegistry = {
     defaultSweepScale: 'linear',
   },
 
+  // Cache reliability
+  cacheReliability: {
+    paramKind: 'numeric',
+    displayName: 'Cache reliability',
+    group: 'context-compaction',
+    isConversationShape: false,
+    uiMin: 0,
+    uiMax: 1,
+    uiStep: 0.01,
+    displayMultiplier: 1,
+    defaultSweepMin: 0.5,
+    defaultSweepMax: 1.0,
+    defaultSweepSteps: 6,
+    defaultSweepScale: 'linear',
+  },
+
   // Strategy 2 — Incremental compaction
   incrementalInterval: {
     paramKind: 'numeric',

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -52,6 +52,9 @@ export interface SimulationConfig {
   readonly lcmGrepRatio: number
   readonly lcmGrepResponseTokens: number
 
+  // Cache reliability
+  readonly cacheReliability: number
+
   // Pricing (per token, not per million)
   readonly baseInputPrice: number
   readonly outputPrice: number
@@ -147,6 +150,9 @@ export const DEFAULT_CONFIG: SimulationConfig = {
   contextWindow: 200_000,
   compactionThreshold: 0.85,
   compressionRatio: 10,
+
+  // Cache reliability
+  cacheReliability: 1.0,
 
   // Pricing (per token)
   baseInputPrice: 5.0 / 1_000_000,


### PR DESCRIPTION
## Summary

- Adds `cacheReliability` parameter (0.0–1.0, default 1.0) to `SimulationConfig` that probabilistically degrades cache hits on stable prefixes
- On each LLM call step, even with a stable prefix, there's a `(1 - cacheReliability)` chance of a full cache miss
- At default 1.0, no RNG call is made — exact backwards compatibility preserved
- Parameter exposed in web UI (Context & Compaction section) and sweep-compatible via `PARAM_META`

## Engine Change

**What changed**: New `cacheReliability` field in `SimulationConfig`. Probabilistic degradation implemented in `calculateCache` (simulation.ts) using the existing seeded PRNG. The cache model itself (`cache.ts`) is unchanged — degradation is applied post-calculation.

**Why**: The prefix cache model is perfectly deterministic — stable prefix = guaranteed hit. Real API caching is erratic (sporadic misses, server-side eviction, TTL). Cost analysis shows cached input dominates total cost (51–77%), so cache model fidelity directly affects findings. This parameter enables stress-testing all prior conclusions against realistic cache behaviour.

**Motivated by**: FINDINGS.md modelling limitation #5, identified during Phase 2 review.

## Test plan

- [x] 5 new tests: identity at 1.0, zero hits at 0.0, cost monotonicity, hit-rate monotonicity, determinism
- [x] All 181 existing tests pass
- [x] TypeScript compiles cleanly
- [x] Lint clean (only pre-existing warnings)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)