### PR TITLE
Fix extract_handoff crash on Windows

### DIFF
--- a/experiments/run-loop.sh
+++ b/experiments/run-loop.sh
@@ -109,20 +109,24 @@ extract_summary() {
 extract_handoff() {
   local result="$1"
   echo "$result" | node -e "
-const lines = require('fs').readFileSync('/dev/stdin', 'utf-8').split('\n');
-let inHandoff = false;
-let next = '';
-for (const line of lines) {
-  if (line.trim() === '## Handoff') { inHandoff = true; continue; }
-  if (inHandoff && line.match(/\*\*Next:\*\*/)) {
-    const m = line.match(/\*\*Next:\*\*\s*(\S+)/);
-    if (m) next = m[1];
-    break;
+let buf = '';
+process.stdin.setEncoding('utf-8');
+process.stdin.on('data', c => buf += c);
+process.stdin.on('end', () => {
+  const lines = buf.split('\n');
+  let inHandoff = false;
+  let next = '';
+  for (const line of lines) {
+    if (line.trim() === '## Handoff') { inHandoff = true; continue; }
+    if (inHandoff && line.match(/\*\*Next:\*\*/)) {
+      const m = line.match(/\*\*Next:\*\*\s*(\S+)/);
+      if (m) next = m[1];
+      break;
+    }
+    if (inHandoff && line.startsWith('## ')) break;
   }
-  // Stop if we hit another heading after Handoff
-  if (inHandoff && line.startsWith('## ')) break;
-}
-process.stdout.write(next);
+  process.stdout.write(next);
+});
 "
 }
 


### PR DESCRIPTION
## Summary
- `extract_handoff()` in `run-loop.sh` used `readFileSync('/dev/stdin')` which resolves to `C:\dev\stdin` on Windows, crashing the ralph loop after the first iteration
- Replaced with the async `process.stdin` API which works cross-platform

Closes #101

## Test plan
- [x] Run `./experiments/run-loop.sh 3` on Windows and verify handoff works across multiple iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)