### PR TITLE
Fix loop merge hygiene and add FEEDBACK.md mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Thumbs.db
 
 # Experiment data (large, ephemeral simulation outputs)
 experiments/data/
+
+# Ephemeral loop control files
+experiments/FEEDBACK.md
+experiments/PAUSE

--- a/experiments/PROFESSOR_PROMPT.md
+++ b/experiments/PROFESSOR_PROMPT.md
@@ -20,6 +20,7 @@ You always keep in mind the **overall goal**: informing real engineering decisio
 - Write analysis scripts
 - Make engine changes
 - Write journal entries (you review them, students write them)
+- **Commit directly to main** — all changes (including FINDINGS.md updates, issue direction notes, etc.) go on a branch via a PR. Use `professor/<short-title>` branch naming.
 
 ## Iteration protocol
 

--- a/experiments/SHARED_CONTEXT.md
+++ b/experiments/SHARED_CONTEXT.md
@@ -67,11 +67,32 @@ gh issue view <number> -R TagloGit/compact-sim
 
 ### Branch and PR conventions
 
+- **Never commit directly to main.** All work goes on a branch via a PR — no exceptions, even for small fixes or FINDINGS.md updates. If you catch yourself on `main`, create a branch before committing.
 - **One PR per issue.** Each issue gets its own branch and PR.
-- Branch naming: `experiment/NNN-short-title` (e.g. `experiment/003-cache-sensitivity`)
-- PR description includes `Closes #N` to auto-close the issue on merge
-- **Merge your own PRs** (squash merge to main) and set the issue label to `status: done`. Only leave a PR open if you need Tim's input — in that case, set the issue to `blocked: tim` and explain what you need in a comment.
-- **Wait for CI before merging** — always check that CI checks have passed before merging a PR. Use `gh pr checks <number> -R TagloGit/compact-sim` to verify. Do not merge while checks are still running. CI runs the full test suite (`npm test`), lint, and build — so **you do not need to run tests locally** before pushing. CI will catch any issues. This saves time; focus your iteration on the actual work.
+- Branch naming: `experiment/NNN-short-title` (e.g. `experiment/003-cache-sensitivity`). Professor branches: `professor/short-title`.
+- PR description includes `Closes #N` to auto-close the issue on merge.
+- **Merge your own PRs** and set the issue label to `status: done`. Only leave a PR open if you need Tim's input — in that case, set the issue to `blocked: tim` and explain what you need in a comment.
+- **Wait for CI before merging** — use `gh pr checks <number> -R TagloGit/compact-sim` to verify all checks pass before merging. Do not merge while checks are still running. CI runs tests, lint, and build — so you do not need to run tests locally.
+
+### Merge and cleanup procedure
+
+**Always follow this exact sequence when merging a PR:**
+
+```bash
+# 1. Squash merge via GitHub CLI (NEVER use regular merge)
+gh pr merge <number> -R TagloGit/compact-sim --squash --delete-branch
+
+# 2. Switch to main and pull the merged commit
+git checkout main
+git pull
+
+# 3. Delete the local branch (if it still exists)
+git branch -d <branch-name>
+```
+
+- **Only squash merges.** Never use `--merge` or `--rebase` on the CLI. Never use the GitHub merge button without squash.
+- **`--delete-branch`** removes the remote branch on merge. Step 3 cleans up the local copy.
+- **Always pull after merge** to sync your local main with the remote. Skipping this causes merge commits on the next push.
 
 ## Findings (`experiments/FINDINGS.md`)
 
@@ -117,6 +138,16 @@ When you identify a modelling gap, you can modify the simulation engine directly
 - You may merge engine-change PRs without Tim's approval
 - After engine changes, assess impact on prior findings and note any invalidated results in `FINDINGS.md`
 - **Frontend required**: any new parameters or changed defaults MUST also be added to the web UI (`src/components/controls/ParameterPanel.tsx`, `src/components/explorer/SweepParameterPanel.tsx`, etc.) so Tim can use them in the browser. Do not merge engine PRs that add parameters without corresponding frontend support.
+
+## Feedback from Tim
+
+Tim can leave feedback between iterations by writing to `experiments/FEEDBACK.md`. If this file is present, its contents will be appended to your prompt automatically.
+
+When you see a `## Feedback from Tim` section at the end of your prompt:
+1. **Read it carefully** — this is direct input from Tim and takes priority over backlog items
+2. **Acknowledge it** in your iteration summary
+3. **Act on it** — adjust your plans, update issues, or change direction as requested
+4. **Delete the file** — run `rm experiments/FEEDBACK.md` so it doesn't repeat next iteration
 
 ## Constraints
 

--- a/experiments/STUDENT_PROMPT.md
+++ b/experiments/STUDENT_PROMPT.md
@@ -33,7 +33,7 @@ You don't decide what to investigate — that's your director's job. You pick up
 4. **Do the work** — one task only. Follow the issue's acceptance criteria.
 5. **Write up** — journal entry for experiments, PR description for engine changes
 6. **Update state** — raise PR with `Closes #N`, update issue labels, merge if appropriate, update FINDINGS.md
-7. **Clean up branches** — after merging a PR, delete the local branch: `git branch -d <branch-name>`. Origin branches are deleted automatically on merge.
+7. **Merge and clean up** — follow the merge procedure in the shared context exactly: squash merge with `--delete-branch`, checkout main, pull, delete local branch.
 8. **Hand off** — you MUST end with the handoff block (see below)
 
 ## Engine changes — frontend requirement

--- a/experiments/run-loop.sh
+++ b/experiments/run-loop.sh
@@ -25,6 +25,7 @@
 VERBOSE=false
 PERSONA="professor"
 SHARED_CONTEXT="experiments/SHARED_CONTEXT.md"
+FEEDBACK_FILE="experiments/FEEDBACK.md"
 
 while [[ "$1" == -* ]]; do
   case "$1" in
@@ -72,6 +73,18 @@ build_prompt() {
   fi
 
   cat "$prompt_file" "$SHARED_CONTEXT"
+
+  # Inject feedback from Tim if the file exists and is non-empty
+  if [ -s "$FEEDBACK_FILE" ]; then
+    echo ""
+    echo "---"
+    echo ""
+    echo "## Feedback from Tim"
+    echo ""
+    echo "Tim has left the following feedback. Read it carefully, acknowledge it in your response, and act on it. After reading, delete the file (\`rm experiments/FEEDBACK.md\`) so it is not repeated in the next iteration."
+    echo ""
+    cat "$FEEDBACK_FILE"
+  fi
 }
 
 # Extracts the result text from a stream-json session file.
@@ -165,6 +178,10 @@ echo ""
 while [ $iteration -lt $MAX_ITERATIONS ]; do
   iteration=$((iteration + 1))
   echo "=== Iteration $iteration / $MAX_ITERATIONS [$PERSONA] ==="
+
+  if [ -s "$FEEDBACK_FILE" ]; then
+    echo "  [feedback injected from $FEEDBACK_FILE]"
+  fi
 
   session_file="experiments/data/session-${iteration}.json"
   prompt=$(build_prompt "$PERSONA")


### PR DESCRIPTION
## Summary
- **Merge hygiene**: Added explicit "never commit to main" rules and a strict 3-step merge procedure (`gh pr merge --squash --delete-branch`, checkout main, pull) to prevent the merge commit mess seen in recent history
- **Feedback channel**: Added `experiments/FEEDBACK.md` as a lightweight way for Tim to inject feedback into the next loop iteration — the loop script detects the file, appends it to the prompt, and the agent deletes it after reading
- **Gitignore**: Added `FEEDBACK.md` and `PAUSE` (both ephemeral control files) to `.gitignore`

## Test plan
- [x] Start a loop, verify no merge commit noise on PR merges
- [x] Write `experiments/FEEDBACK.md`, start loop, verify agent sees and acknowledges it
- [x] Verify `FEEDBACK.md` and `PAUSE` don't show up in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)