### PR TITLE
Add iteration-to-iteration handoff messaging for research loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ experiments/data/
 
 # Ephemeral loop control files
 experiments/FEEDBACK.md
+experiments/HANDOFF.md
 experiments/PAUSE

--- a/experiments/SHARED_CONTEXT.md
+++ b/experiments/SHARED_CONTEXT.md
@@ -149,6 +149,27 @@ When you see a `## Feedback from Tim` section at the end of your prompt:
 3. **Act on it** — adjust your plans, update issues, or change direction as requested
 4. **Delete the file** — run `rm experiments/FEEDBACK.md` so it doesn't repeat next iteration
 
+## Handoff messages between iterations
+
+Each iteration is a fresh session — you cannot talk to the next iteration directly. To pass a message, write to `experiments/HANDOFF.md`. The loop harness will inject its contents into the next iteration's prompt, just like Tim's feedback file.
+
+Use this when the next iteration needs specific direction that isn't captured in the issue backlog alone. For example:
+- "Pick up #112 before anything else — it's a blocking CI issue"
+- "I started the analysis but ran out of context — the branch is `experiment/015-foo`, continue from there"
+- "Re-run experiment 012 with the updated engine before starting new work"
+
+**Writing a handoff message:**
+
+```bash
+cat > experiments/HANDOFF.md << 'EOF'
+Your message here. Be specific about what the next iteration should do and why.
+EOF
+```
+
+**Reading a handoff message:** If you see a `## Handoff from previous iteration` section at the end of your prompt, that takes priority over normal backlog selection. After reading, delete the file (`rm experiments/HANDOFF.md`) so it doesn't repeat.
+
+The loop also automatically injects the previous iteration's summary block (if one was produced), so you always have basic context about what just happened — even without an explicit handoff message.
+
 ## Constraints
 
 - Focus on experiments, analysis, findings, and engine improvements when needed

--- a/experiments/STUDENT_PROMPT.md
+++ b/experiments/STUDENT_PROMPT.md
@@ -8,7 +8,7 @@ You don't decide what to investigate — that's your director's job. You pick up
 
 ## Your responsibilities
 
-1. **Pick up a single task** — find the highest-priority `status: backlog` experiment issue and work on it. If an issue is `status: in-progress`, it may need continuing from a previous iteration.
+1. **Pick up a single task** — if there's a handoff directive from the previous iteration, that takes priority. Otherwise, find the highest-priority `status: backlog` experiment issue and work on it. If an issue is `status: in-progress`, it may need continuing from a previous iteration.
 2. **Execute the work** — run simulations, analyse results, write journal entries, make engine changes. One issue per iteration.
 3. **Write it up** — every experiment gets a journal entry. Every engine change gets a well-described PR.
 4. **Be critical of your own results** — if something looks too clean or too good, investigate why. Flag modelling artefacts explicitly.

--- a/experiments/run-loop.sh
+++ b/experiments/run-loop.sh
@@ -26,6 +26,8 @@ VERBOSE=false
 PERSONA="professor"
 SHARED_CONTEXT="experiments/SHARED_CONTEXT.md"
 FEEDBACK_FILE="experiments/FEEDBACK.md"
+HANDOFF_FILE="experiments/HANDOFF.md"
+PREV_SUMMARY=""
 
 while [[ "$1" == -* ]]; do
   case "$1" in
@@ -84,6 +86,28 @@ build_prompt() {
     echo "Tim has left the following feedback. Read it carefully, acknowledge it in your response, and act on it. After reading, delete the file (\`rm experiments/FEEDBACK.md\`) so it is not repeated in the next iteration."
     echo ""
     cat "$FEEDBACK_FILE"
+  fi
+
+  # Inject handoff message from previous iteration if the file exists and is non-empty
+  if [ -s "$HANDOFF_FILE" ]; then
+    echo ""
+    echo "---"
+    echo ""
+    echo "## Handoff from previous iteration"
+    echo ""
+    echo "The previous iteration left the following handoff message for you. This takes priority over normal backlog selection. After reading, delete the file (\`rm experiments/HANDOFF.md\`) so it is not repeated in the next iteration."
+    echo ""
+    cat "$HANDOFF_FILE"
+  fi
+
+  # Inject previous iteration's summary if available
+  if [ -n "$PREV_SUMMARY" ]; then
+    echo ""
+    echo "---"
+    echo ""
+    echo "## Previous iteration summary"
+    echo ""
+    echo "$PREV_SUMMARY"
   fi
 }
 
@@ -232,6 +256,9 @@ while [ $iteration -lt $MAX_ITERATIONS ]; do
   extract_cost "$session_file"
   echo "--- Session: $session_file ---"
   echo ""
+
+  # Capture summary for injection into next iteration
+  PREV_SUMMARY="$summary"
 
   # Extract handoff signal
   handoff=$(extract_handoff "$result")


### PR DESCRIPTION
## Summary
- Adds `HANDOFF.md` mechanism for explicit iteration-to-iteration messaging (either persona can write, next iteration gets it injected into prompt)
- Automatically injects previous iteration's summary block into the next prompt
- Student prompt updated to prioritise handoff directives over normal backlog selection

## Test plan
- [x] Run loop with 2+ iterations and verify previous summary appears in next prompt
- [x] Write a HANDOFF.md manually, run an iteration, verify it's injected and agent deletes it
- [x] Verify HANDOFF.md is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)