### PR TITLE
[engine] Add summary growth model for sublinear summary sizing

### DIFF
--- a/src/components/controls/ParameterPanel.tsx
+++ b/src/components/controls/ParameterPanel.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { ChevronDown } from 'lucide-react'
-import type { SimulationConfig } from '@/engine/types'
-import type { StrategyType } from '@/engine/types'
+import type { SimulationConfig, StrategyType, SummaryGrowthModel } from '@/engine/types'
 import { PARAM_META, type NumericParamMeta } from '@/engine/sweep-defaults'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
 import { Label } from '@/components/ui/label'
@@ -212,6 +211,46 @@ function StrategySelect({ value, onChange }: StrategySelectProps) {
   )
 }
 
+// --- Summary growth model select (deferred update) ---
+
+interface SummaryGrowthSelectProps {
+  value: SummaryGrowthModel
+  onChange: (value: SummaryGrowthModel) => void
+}
+
+function SummaryGrowthSelect({ value, onChange }: SummaryGrowthSelectProps) {
+  const [local, setLocal] = useState(value)
+
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+
+  const handleChange = useCallback(
+    (v: string | null) => {
+      if (v === null) return
+      const typed = v as SummaryGrowthModel
+      setLocal(typed)
+      setTimeout(() => onChange(typed), 0)
+    },
+    [onChange],
+  )
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-muted-foreground">Summary growth model</Label>
+      <Select value={local} onValueChange={handleChange}>
+        <SelectTrigger className="h-8 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="fixed" className="text-xs">Fixed (convergent)</SelectItem>
+          <SelectItem value="logarithmic" className="text-xs">Logarithmic growth</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
 // --- Deferred switch ---
 
 interface DeferredSwitchProps {
@@ -374,6 +413,13 @@ export function ParameterPanel({ config, onUpdate }: ParameterPanelProps) {
             {slider('contextWindow')}
             {slider('compactionThreshold')}
             {slider('compressionRatio')}
+
+            <SummaryGrowthSelect
+              value={config.summaryGrowthModel}
+              onChange={(v) => onUpdate('summaryGrowthModel', v)}
+            />
+            {config.summaryGrowthModel === 'logarithmic' && slider('summaryGrowthCoefficient')}
+
             {numberInput('cacheReliability')}
           </div>
         </CollapsibleContent>

--- a/src/components/explorer/HeatBar.tsx
+++ b/src/components/explorer/HeatBar.tsx
@@ -360,6 +360,7 @@ export function HeatBar({ results, selectedMetric, selectedIndex, onSelect, swep
 function formatParamValue(key: keyof SimulationConfig, value: SimulationConfig[keyof SimulationConfig]): string {
   const meta = PARAM_META[key]
   if (meta.paramKind === 'strategy') return String(value)
+  if (meta.paramKind === 'summaryGrowth') return String(value)
   if (meta.paramKind === 'boolean') return value ? 'On' : 'Off'
   const numMeta = meta
   const displayVal = (value as number) * numMeta.displayMultiplier

--- a/src/components/explorer/RunDetailCard.tsx
+++ b/src/components/explorer/RunDetailCard.tsx
@@ -111,6 +111,7 @@ function formatConfigValue(
   meta: (typeof PARAM_META)[keyof SimulationConfig],
 ): string {
   if (meta.paramKind === 'strategy') return String(value)
+  if (meta.paramKind === 'summaryGrowth') return String(value)
   if (meta.paramKind === 'boolean') return value ? 'On' : 'Off'
   const displayVal = (value as number) * meta.displayMultiplier
   if (Number.isInteger(displayVal)) return displayVal.toLocaleString()

--- a/src/components/explorer/SweepParameterPanel.tsx
+++ b/src/components/explorer/SweepParameterPanel.tsx
@@ -1,8 +1,8 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { GripVertical, ChevronDown, Lock, Unlock } from 'lucide-react'
-import type { SimulationConfig, StrategyType } from '@/engine/types'
+import type { SimulationConfig, StrategyType, SummaryGrowthModel } from '@/engine/types'
 import { DEFAULT_CONFIG } from '@/engine/types'
-import type { SweepConfig, SweepParameterDef, NumericSweepRange, ParamScale } from '@/engine/sweep-types'
+import type { SweepConfig, SweepParameterDef, NumericSweepRange, ParamScale, SummaryGrowthSweepRange } from '@/engine/sweep-types'
 import { PARAM_META, type ParamGroup, type NumericParamMeta } from '@/engine/sweep-defaults'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
 import { Input } from '@/components/ui/input'
@@ -23,6 +23,12 @@ const STRATEGY_OPTIONS: { value: StrategyType; label: string }[] = [
   { value: 'lossless-hierarchical', label: '4b — Lossless hierarchical' },
   { value: 'lossless-tool-results', label: '4c — Tool-results lossless' },
   { value: 'lcm-subagent', label: '4d — LCM sub-agent' },
+]
+
+// All summary growth model options
+const SUMMARY_GROWTH_OPTIONS: { value: SummaryGrowthModel; label: string }[] = [
+  { value: 'fixed', label: 'Fixed (convergent)' },
+  { value: 'logarithmic', label: 'Logarithmic growth' },
 ]
 
 // Group display order and labels
@@ -55,6 +61,7 @@ function getStepCount(key: keyof SimulationConfig, def: SweepParameterDef): numb
   if (def.kind === 'fixed') return 1
   const meta = PARAM_META[key]
   if (meta.paramKind === 'strategy') return (def as { values: StrategyType[] }).values.length
+  if (meta.paramKind === 'summaryGrowth') return (def as { values: SummaryGrowthModel[] }).values.length
   if (meta.paramKind === 'boolean') return 2
   return (def as NumericSweepRange).steps
 }
@@ -64,6 +71,9 @@ function toSwept(key: keyof SimulationConfig): SweepParameterDef {
   const meta = PARAM_META[key]
   if (meta.paramKind === 'strategy') {
     return { kind: 'swept', values: STRATEGY_OPTIONS.map((o) => o.value) }
+  }
+  if (meta.paramKind === 'summaryGrowth') {
+    return { kind: 'swept', values: SUMMARY_GROWTH_OPTIONS.map((o) => o.value) }
   }
   if (meta.paramKind === 'boolean') {
     return { kind: 'swept' }
@@ -205,6 +215,22 @@ function FixedValueEditor({
         </SelectTrigger>
         <SelectContent>
           {STRATEGY_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value} className="text-xs">
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+  if (meta.paramKind === 'summaryGrowth') {
+    return (
+      <Select value={value as string} onValueChange={(v) => { if (v) onChange(v) }}>
+        <SelectTrigger className="h-6 w-auto max-w-[180px] text-xs text-muted-foreground border-none shadow-none px-1 hover:bg-muted">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {SUMMARY_GROWTH_OPTIONS.map((opt) => (
             <SelectItem key={opt.value} value={opt.value} className="text-xs">
               {opt.label}
             </SelectItem>
@@ -360,6 +386,29 @@ function ParamRow({
           values={(def as { values: StrategyType[] }).values}
           onChange={(values) => onUpdate({ kind: 'swept', values })}
         />
+      )}
+      {isSwept && meta.paramKind === 'summaryGrowth' && (
+        <div className="mt-1.5 space-y-1 pl-5">
+          {SUMMARY_GROWTH_OPTIONS.map((opt) => (
+            <label key={opt.value} className="flex items-center gap-2 text-xs cursor-pointer">
+              <input
+                type="checkbox"
+                checked={(def as SummaryGrowthSweepRange).values.includes(opt.value)}
+                onChange={(e) => {
+                  const current = (def as SummaryGrowthSweepRange).values
+                  if (e.target.checked) {
+                    onUpdate({ kind: 'swept', values: [...current, opt.value] })
+                  } else {
+                    const next = current.filter((v) => v !== opt.value)
+                    if (next.length > 0) onUpdate({ kind: 'swept', values: next })
+                  }
+                }}
+                className="size-3.5 rounded border-border accent-foreground"
+              />
+              <span className="text-muted-foreground">{opt.label}</span>
+            </label>
+          ))}
+        </div>
       )}
       {isSwept && meta.paramKind === 'boolean' && (
         <div className="mt-0.5 pl-5">

--- a/src/engine/__tests__/summary-growth.test.ts
+++ b/src/engine/__tests__/summary-growth.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import { Effect } from 'effect'
+import { applySummaryFloor } from '../strategy'
+import { runSimulation } from '../simulation'
+import type { SimulationConfig } from '../types'
+import { DEFAULT_CONFIG } from '../types'
+
+function run(config: SimulationConfig) {
+  return Effect.runSync(runSimulation(config))
+}
+
+describe('applySummaryFloor', () => {
+  it('returns computedTokens unchanged for fixed model', () => {
+    const config = { ...DEFAULT_CONFIG, summaryGrowthModel: 'fixed' as const }
+    expect(applySummaryFloor(500, 100_000, config)).toBe(500)
+  })
+
+  it('returns computedTokens when above floor for logarithmic model', () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      summaryGrowthModel: 'logarithmic' as const,
+      summaryGrowthCoefficient: 1000,
+    }
+    // floor = 1000 * ln(1 + 10000/1000) = 1000 * ln(11) ≈ 2397
+    // computedTokens = 5000 > 2397 → returns 5000
+    expect(applySummaryFloor(5000, 10_000, config)).toBe(5000)
+  })
+
+  it('applies floor when computedTokens is below floor for logarithmic model', () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      summaryGrowthModel: 'logarithmic' as const,
+      summaryGrowthCoefficient: 1000,
+    }
+    // floor = 1000 * ln(1 + 100000/1000) = 1000 * ln(101) ≈ 4615
+    // computedTokens = 3000 < 4615 → returns ceil(4615)
+    const result = applySummaryFloor(3000, 100_000, config)
+    expect(result).toBeGreaterThan(3000)
+    expect(result).toBe(Math.ceil(1000 * Math.log(1 + 100_000 / 1000)))
+  })
+
+  it('floor grows with totalCompressedTokens', () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      summaryGrowthModel: 'logarithmic' as const,
+      summaryGrowthCoefficient: 1000,
+    }
+    const floor10k = applySummaryFloor(0, 10_000, config)
+    const floor100k = applySummaryFloor(0, 100_000, config)
+    const floor300k = applySummaryFloor(0, 300_000, config)
+    expect(floor100k).toBeGreaterThan(floor10k)
+    expect(floor300k).toBeGreaterThan(floor100k)
+  })
+})
+
+describe('summary growth — full simulation', () => {
+  // Base config designed for predictable compaction behaviour
+  const baseConfig: SimulationConfig = {
+    ...DEFAULT_CONFIG,
+    toolCallCycles: 200,
+    contextWindow: 200_000,
+    compactionThreshold: 0.85,
+    compressionRatio: 10,
+    incrementalInterval: 30_000,
+    selectedStrategy: 'incremental',
+  }
+
+  it('fixed model produces identical results to default (backwards compatibility)', () => {
+    const defaultResult = run({ ...baseConfig })
+    const fixedResult = run({ ...baseConfig, summaryGrowthModel: 'fixed' })
+
+    expect(fixedResult.summary.totalCost).toBe(defaultResult.summary.totalCost)
+    expect(fixedResult.summary.compactionEvents).toBe(defaultResult.summary.compactionEvents)
+    expect(fixedResult.summary.peakContextSize).toBe(defaultResult.summary.peakContextSize)
+  })
+
+  it('fixed model summary converges (stable after a few compactions)', () => {
+    const result = run({ ...baseConfig, summaryGrowthModel: 'fixed' })
+
+    // Get summary sizes at each compaction event
+    const compactionSteps = result.snapshots.filter((s) => s.compactionEvent)
+    expect(compactionSteps.length).toBeGreaterThanOrEqual(3)
+
+    // Find summary messages in context after each compaction
+    const summarySizes = compactionSteps.map((step) => {
+      const summaries = step.context.messages.filter((m) => m.type === 'summary')
+      return summaries.reduce((sum, m) => sum + m.tokens, 0)
+    })
+
+    // After the first 2-3 compactions, summary size should converge
+    // (last few values should be very close to each other)
+    const lastThree = summarySizes.slice(-3)
+    if (lastThree.length === 3) {
+      const maxDiff = Math.max(...lastThree) - Math.min(...lastThree)
+      // Should be within 50% of the mean — convergence (incremental accumulates
+      // multiple summaries, so total fluctuates around the convergence ceiling)
+      const mean = lastThree.reduce((a, b) => a + b, 0) / lastThree.length
+      expect(maxDiff / mean).toBeLessThan(0.5)
+    }
+  })
+
+  it('logarithmic model summary grows beyond fixed convergence point', () => {
+    const fixedResult = run({ ...baseConfig, summaryGrowthModel: 'fixed' })
+    const logResult = run({
+      ...baseConfig,
+      summaryGrowthModel: 'logarithmic',
+      summaryGrowthCoefficient: 1000,
+    })
+
+    // Both should have compaction events
+    expect(fixedResult.summary.compactionEvents).toBeGreaterThanOrEqual(3)
+    expect(logResult.summary.compactionEvents).toBeGreaterThanOrEqual(3)
+
+    // Get final summary sizes
+    const getLastSummarySize = (snapshots: typeof fixedResult.snapshots) => {
+      const lastCompaction = [...snapshots].reverse().find((s) => s.compactionEvent)
+      if (!lastCompaction) return 0
+      const summaries = lastCompaction.context.messages.filter((m) => m.type === 'summary')
+      return summaries.reduce((sum, m) => sum + m.tokens, 0)
+    }
+
+    const fixedFinalSummary = getLastSummarySize(fixedResult.snapshots)
+    const logFinalSummary = getLastSummarySize(logResult.snapshots)
+
+    // Logarithmic model should produce a larger final summary
+    expect(logFinalSummary).toBeGreaterThan(fixedFinalSummary)
+  })
+
+  it('logarithmic model summary grows over successive compactions', () => {
+    const result = run({
+      ...baseConfig,
+      summaryGrowthModel: 'logarithmic',
+      summaryGrowthCoefficient: 1000,
+    })
+
+    const compactionSteps = result.snapshots.filter((s) => s.compactionEvent)
+    expect(compactionSteps.length).toBeGreaterThanOrEqual(3)
+
+    // Get the total summary token size in context after each compaction
+    const summarySizes = compactionSteps.map((step) => {
+      const summaries = step.context.messages.filter((m) => m.type === 'summary')
+      return summaries.reduce((sum, m) => sum + m.tokens, 0)
+    })
+
+    // After the initial ramp-up, the summary size should be growing
+    // (at least the last value should be larger than the second)
+    const last = summarySizes[summarySizes.length - 1]
+    const secondToLast = summarySizes[summarySizes.length - 2]
+    // For incremental strategy, summaries accumulate — check last compaction produces larger summary
+    expect(last).toBeGreaterThanOrEqual(secondToLast)
+  })
+})

--- a/src/engine/simulation.ts
+++ b/src/engine/simulation.ts
@@ -116,7 +116,7 @@ export function evaluateCompaction(
   config: SimulationConfig,
 ): StepState {
   const strategy = getStrategy(config.selectedStrategy)
-  const result = strategy.evaluate(state.context, config)
+  const result = strategy.evaluate(state.context, config, state.compressedTokens)
 
   if (!result.shouldCompact || !result.newContext || !result.summaryMessage) {
     return state

--- a/src/engine/strategy.ts
+++ b/src/engine/strategy.ts
@@ -21,7 +21,27 @@ export interface CompactionStrategy {
   readonly evaluate: (
     context: ContextState,
     config: SimulationConfig,
+    compressedTokens?: number,
   ) => CompactionResult
+}
+
+/**
+ * Apply summary growth floor based on the configured growth model.
+ *
+ * - 'fixed': no change (returns computedTokens as-is)
+ * - 'logarithmic': floor = coefficient × ln(1 + totalCompressedTokens / 1000)
+ *
+ * The floor ensures summaries grow sublinearly with total compressed content,
+ * preventing convergence to a fixed ceiling in long sessions.
+ */
+export function applySummaryFloor(
+  computedTokens: number,
+  totalCompressedTokens: number,
+  config: SimulationConfig,
+): number {
+  if (config.summaryGrowthModel === 'fixed') return computedTokens
+  const floor = config.summaryGrowthCoefficient * Math.log(1 + totalCompressedTokens / 1000)
+  return Math.max(computedTokens, Math.ceil(floor))
 }
 
 export class Strategy extends Context.Tag('Strategy')<
@@ -37,7 +57,7 @@ export class Strategy extends Context.Tag('Strategy')<
  * Summary size = compacted tokens / compression ratio.
  */
 export const strategy1: CompactionStrategy = {
-  evaluate(context, config) {
+  evaluate(context, config, compressedTokens = 0) {
     const threshold = config.compactionThreshold * config.contextWindow
     if (context.totalTokens <= threshold) {
       return { shouldCompact: false }
@@ -52,7 +72,11 @@ export const strategy1: CompactionStrategy = {
       (sum, m) => sum + m.tokens,
       0,
     )
-    const summaryTokens = Math.ceil(compactedTokens / config.compressionRatio)
+    const summaryTokens = applySummaryFloor(
+      Math.ceil(compactedTokens / config.compressionRatio),
+      compressedTokens + compactedTokens,
+      config,
+    )
 
     const summaryMessage: Message = {
       id: `summary-${Date.now()}`,
@@ -92,7 +116,7 @@ export const strategy1: CompactionStrategy = {
  * Context shape: [system] [summary_1] ... [summary_N] [recent raw content]
  */
 export const strategy2: CompactionStrategy = {
-  evaluate(context, config) {
+  evaluate(context, config, compressedTokens = 0) {
     const systemMessage = context.messages.find((m) => m.type === 'system')
     const nonSystemMessages = context.messages.filter(
       (m) => m.type !== 'system',
@@ -121,8 +145,10 @@ export const strategy2: CompactionStrategy = {
     }
 
     // Compact new content into a summary
-    const summaryTokens = Math.ceil(
-      newContentTokens / config.compressionRatio,
+    const summaryTokens = applySummaryFloor(
+      Math.ceil(newContentTokens / config.compressionRatio),
+      compressedTokens + newContentTokens,
+      config,
     )
     const newSummary: Message = {
       id: `summary-${Date.now()}`,
@@ -144,8 +170,10 @@ export const strategy2: CompactionStrategy = {
     // Meta-compaction: if accumulated summaries exceed threshold, re-compact
     let metaCompactionSummary: Message | undefined
     if (totalSummaryTokens > config.summaryAccumulationThreshold) {
-      const metaSummaryTokens = Math.ceil(
-        totalSummaryTokens / config.compressionRatio,
+      const metaSummaryTokens = applySummaryFloor(
+        Math.ceil(totalSummaryTokens / config.compressionRatio),
+        compressedTokens + newContentTokens,
+        config,
       )
       metaCompactionSummary = {
         id: `summary-meta-${Date.now()}`,
@@ -190,8 +218,8 @@ export const strategy2: CompactionStrategy = {
  * a summary, enabling later retrieval.
  */
 export const strategy4a: CompactionStrategy = {
-  evaluate(context, config) {
-    const result = strategy2.evaluate(context, config)
+  evaluate(context, config, compressedTokens = 0) {
+    const result = strategy2.evaluate(context, config, compressedTokens)
     if (!result.shouldCompact || !result.compactedMessageIds) {
       return result
     }
@@ -234,7 +262,7 @@ export const strategy4a: CompactionStrategy = {
  *   sum2 → sum1 → sum0 → original. Cost scales by (level + 1).
  */
 export const strategy4b: CompactionStrategy = {
-  evaluate(context, config) {
+  evaluate(context, config, compressedTokens = 0) {
     const systemMessage = context.messages.find((m) => m.type === 'system')
     const nonSystemMessages = context.messages.filter(
       (m) => m.type !== 'system',
@@ -267,7 +295,11 @@ export const strategy4b: CompactionStrategy = {
       (sum, m) => sum + m.tokens,
       0,
     )
-    const summaryTokens = Math.ceil(allNonSystemTokens / config.compressionRatio)
+    const summaryTokens = applySummaryFloor(
+      Math.ceil(allNonSystemTokens / config.compressionRatio),
+      compressedTokens + allNonSystemTokens,
+      config,
+    )
     const summaryMessage: Message = {
       id: `summary-${Date.now()}`,
       type: 'summary',
@@ -315,8 +347,8 @@ export const strategy4b: CompactionStrategy = {
  * tokens that were compressed, not all compressed tokens.
  */
 export const strategy4c: CompactionStrategy = {
-  evaluate(context, config) {
-    const result = strategy2.evaluate(context, config)
+  evaluate(context, config, compressedTokens = 0) {
+    const result = strategy2.evaluate(context, config, compressedTokens)
     if (!result.shouldCompact || !result.compactedMessageIds) {
       return result
     }
@@ -367,7 +399,7 @@ export const strategy4c: CompactionStrategy = {
  * the `lcmSubagentRetrievalCost` function in retrieval.ts.
  */
 export const strategy4d: CompactionStrategy = {
-  evaluate(context, config) {
+  evaluate(context, config, compressedTokens = 0) {
     const systemMessage = context.messages.find((m) => m.type === 'system')
     const nonSystemMessages = context.messages.filter(
       (m) => m.type !== 'system',
@@ -400,7 +432,11 @@ export const strategy4d: CompactionStrategy = {
       (sum, m) => sum + m.tokens,
       0,
     )
-    const summaryTokens = Math.ceil(allNonSystemTokens / config.compressionRatio)
+    const summaryTokens = applySummaryFloor(
+      Math.ceil(allNonSystemTokens / config.compressionRatio),
+      compressedTokens + allNonSystemTokens,
+      config,
+    )
     const summaryMessage: Message = {
       id: `summary-${Date.now()}`,
       type: 'summary',

--- a/src/engine/sweep-defaults.ts
+++ b/src/engine/sweep-defaults.ts
@@ -13,7 +13,7 @@ export type ParamGroup =
   | 'lossless-retrieval'
   | 'pricing'
 
-export type ParamKind = 'numeric' | 'strategy' | 'boolean'
+export type ParamKind = 'numeric' | 'strategy' | 'boolean' | 'summaryGrowth'
 
 interface BaseParamMeta {
   readonly displayName: string
@@ -44,7 +44,11 @@ export interface BooleanParamMeta extends BaseParamMeta {
   readonly paramKind: 'boolean'
 }
 
-export type ParamMeta = NumericParamMeta | StrategyParamMeta | BooleanParamMeta
+export interface SummaryGrowthParamMeta extends BaseParamMeta {
+  readonly paramKind: 'summaryGrowth'
+}
+
+export type ParamMeta = NumericParamMeta | StrategyParamMeta | BooleanParamMeta | SummaryGrowthParamMeta
 
 export type ParamMetaRegistry = {
   readonly [K in keyof SimulationConfig]: ParamMeta
@@ -230,6 +234,28 @@ export const PARAM_META: ParamMetaRegistry = {
     defaultSweepMin: 0.5,
     defaultSweepMax: 1.0,
     defaultSweepSteps: 6,
+    defaultSweepScale: 'linear',
+  },
+
+  // Summary growth
+  summaryGrowthModel: {
+    paramKind: 'summaryGrowth',
+    displayName: 'Summary growth model',
+    group: 'incremental',
+    isConversationShape: false,
+  },
+  summaryGrowthCoefficient: {
+    paramKind: 'numeric',
+    displayName: 'Summary growth coefficient',
+    group: 'incremental',
+    isConversationShape: false,
+    uiMin: 100,
+    uiMax: 5_000,
+    uiStep: 100,
+    displayMultiplier: 1,
+    defaultSweepMin: 500,
+    defaultSweepMax: 3_000,
+    defaultSweepSteps: 5,
     defaultSweepScale: 'linear',
   },
 

--- a/src/engine/sweep-types.ts
+++ b/src/engine/sweep-types.ts
@@ -1,4 +1,4 @@
-import type { SimulationConfig, StrategyType } from './types'
+import type { SimulationConfig, StrategyType, SummaryGrowthModel } from './types'
 
 // --- Sweep parameter definitions ---
 
@@ -27,6 +27,11 @@ export interface NumericValuesRange {
   readonly values: number[]
 }
 
+export interface SummaryGrowthSweepRange {
+  readonly kind: 'swept'
+  readonly values: SummaryGrowthModel[]
+}
+
 export interface BooleanSweepRange {
   readonly kind: 'swept'
 }
@@ -34,10 +39,12 @@ export interface BooleanSweepRange {
 export type SweepParameterDef =
   | FixedValue<number>
   | FixedValue<StrategyType>
+  | FixedValue<SummaryGrowthModel>
   | FixedValue<boolean>
   | NumericSweepRange
   | NumericValuesRange
   | StrategySweepRange
+  | SummaryGrowthSweepRange
   | BooleanSweepRange
 
 // --- Sweep configuration ---

--- a/src/engine/sweep.ts
+++ b/src/engine/sweep.ts
@@ -5,6 +5,7 @@ import type {
   SweepParameterDef,
   NumericSweepRange,
   StrategySweepRange,
+  SummaryGrowthSweepRange,
 } from './sweep-types'
 import { PARAM_META, getConversationShapeKeys } from './sweep-defaults'
 
@@ -38,6 +39,9 @@ export function expandParamValues(key: keyof SimulationConfig, def: SweepParamet
   const meta = PARAM_META[key]
   if (meta.paramKind === 'strategy') {
     return (def as StrategySweepRange).values
+  }
+  if (meta.paramKind === 'summaryGrowth') {
+    return (def as SummaryGrowthSweepRange).values
   }
   if (meta.paramKind === 'boolean') {
     return [false, true]

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -9,6 +9,8 @@ export type MessageType =
 
 export type StrategyType = 'full-compaction' | 'incremental' | 'lossless-append' | 'lossless-hierarchical' | 'lossless-tool-results' | 'lcm-subagent'
 
+export type SummaryGrowthModel = 'fixed' | 'logarithmic'
+
 export interface Message {
   readonly id: string
   readonly type: MessageType
@@ -51,6 +53,10 @@ export interface SimulationConfig {
   readonly compressedTokensCap: number
   readonly lcmGrepRatio: number
   readonly lcmGrepResponseTokens: number
+
+  // Summary growth
+  readonly summaryGrowthModel: SummaryGrowthModel
+  readonly summaryGrowthCoefficient: number
 
   // Cache reliability
   readonly cacheReliability: number
@@ -150,6 +156,10 @@ export const DEFAULT_CONFIG: SimulationConfig = {
   contextWindow: 200_000,
   compactionThreshold: 0.85,
   compressionRatio: 10,
+
+  // Summary growth
+  summaryGrowthModel: 'fixed',
+  summaryGrowthCoefficient: 1000,
 
   // Cache reliability
   cacheReliability: 1.0,


### PR DESCRIPTION
## Summary

- Add `summaryGrowthModel` ('fixed' | 'logarithmic') and `summaryGrowthCoefficient` (default: 1000) to `SimulationConfig`
- Extract `applySummaryFloor()` helper applied in all 6 strategies that produce summaries
- Frontend: dropdown select + conditional coefficient slider in both ParameterPanel and SweepParameterPanel
- Sweep support: enum sweep for the model parameter, numeric range for the coefficient
- 8 new tests covering unit behaviour and full-simulation convergence/growth

## Engine Change

**What:** New `summaryGrowthModel` parameter with two modes:
- `'fixed'` (default) — preserves existing convergent behaviour where summary stabilises at `interval / (ratio - 1)` ≈ 3.3k tokens
- `'logarithmic'` — applies a growing floor: `coefficient × ln(1 + totalCompressedTokens / 1000)`, preventing the fixed-ceiling artefact in long sessions

**Why:** At ratio=10 with 30k interval, summaries converge to ~3.3k tokens after 2-3 compactions. For 200-cycle sessions compressing 100k+ of history, a fixed 3.3k summary is unrealistically small. This was identified as modelling limitation #7 in FINDINGS.md and is the critical-path prerequisite for Phase 4 context quality experiments.

**Impact on prior findings:** None — the default `'fixed'` model preserves identical results. Backwards compatibility verified by test.

Closes #95

## Test plan

- [x] `applySummaryFloor` unit tests (fixed passthrough, logarithmic floor, growth monotonicity)
- [x] Full simulation: fixed model produces identical results to default (backwards compat)
- [x] Full simulation: fixed model shows convergence
- [x] Full simulation: logarithmic model grows beyond convergence point
- [x] Full simulation: logarithmic summary grows over successive compactions
- [x] All 194 tests pass
- [x] `npm run build` succeeds
- [x] `npm run lint` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)