### PR TITLE
Exp 013: Summary growth dynamics (#119)

### DIFF
--- a/experiments/FINDINGS.md
+++ b/experiments/FINDINGS.md
@@ -299,11 +299,59 @@ Slower context growth reduces compaction frequency. full-compaction stops compac
 
 ---
 
+## Summary Growth Dynamics (Exp 013)
+
+Three sweeps testing whether logarithmic summary growth (vs fixed convergence) changes strategy rankings or absolute costs. Calibrated baseline, `summaryGrowthCoefficient`=1000 default.
+
+### Fixed vs Logarithmic cost impact (200 cycles)
+
+| Strategy | Fixed | Logarithmic | % Change |
+|---|---|---|---|
+| lcm-subagent | $10.49 | $10.81 | +3.1% |
+| lossless-hierarchical | $11.34 | $11.67 | +2.9% |
+| incremental | $11.43 | $12.30 | +7.6% |
+| lossless-tool-results | $11.63 | $12.21 | +5.0% |
+| lossless-append | $11.92 | $12.79 | +7.3% |
+| full-compaction | $20.71 | $20.71 | 0.0% |
+
+**Rankings stable.** lcm-subagent #1 under both models. Full-replacement strategies (lcm-subagent, lossless-hierarchical) are most resilient to summary growth.
+
+### lcm-subagent advantage widens
+
+| Cycles | Fixed Advantage | Logarithmic Advantage |
+|---|---|---|
+| 100 | 0.5% | 1.5% |
+| 150 | 4.2% | 6.6% |
+| 200 | 8.2% | 12.1% |
+
+### Coefficient sensitivity (logarithmic model, 200 cycles)
+
+| Coefficient | lcm-subagent | incremental | lcm advantage |
+|---|---|---|---|
+| 500 | $10.49 | $11.43 | 8.2% |
+| 1000 | $10.81 | $12.30 | 12.1% |
+| 1500 | $11.39 | $13.77 | 17.3% |
+| 2000 | $11.96 | $13.81 | 13.4% |
+
+Cost swing: 14% (lcm) vs 21% (incremental) across coefficient range. Significant but doesn't affect rankings.
+
+### Growth model × interval interaction
+
+Under logarithmic growth, incremental's optimal interval shifts from 15k to 30k (+28% cost penalty at 15k). lcm-subagent's optimal stays at 15k regardless. This eliminates the "15k is cheapest" artefact from Exp 008 — it was a double artefact (no quality penalty AND fixed convergence).
+
+**Key findings:**
+1. **Phase 1-3 conclusions are fully robust** under more realistic summary growth.
+2. **lcm-subagent advantage amplified** — 12.1% over incremental at 200 cycles (vs 8.2% under fixed).
+3. **30k interval recommendation validated and strengthened** — 15k is harmful under realistic growth.
+4. **Coefficient is a secondary concern** — affects absolute costs 10–24% but never changes rankings.
+
+---
+
 ## Cross-Experiment Conclusions
 
 ### Strategy recommendation for Models Agent
 
-**Use `lcm-subagent` unconditionally.** Across 12 experiments spanning Phase 1 (baselines and parameter sweeps), Phase 2 (retrieval stress tests), and Phase 3 (cache and ingestion), lcm-subagent is the cheapest strategy in every realistic scenario.
+**Use `lcm-subagent` unconditionally.** Across 13 experiments spanning Phase 1 (baselines and parameter sweeps), Phase 2 (retrieval stress tests), Phase 3 (cache and ingestion), and Phase 4 (summary growth dynamics), lcm-subagent is the cheapest strategy in every realistic scenario.
 
 | Session length | Strategy | Cost advantage over next-best | Confidence |
 |---|---|---|---|
@@ -334,7 +382,7 @@ Slower context growth reduces compaction frequency. full-compaction stops compac
 4. **Conversation determinism**: Simulated conversations are deterministic averages. Real conversations have higher variance in tool result sizes and cycle counts.
 5. **Cache model at default is optimistic** (#93, investigated in Exp 011): The `cacheReliability` parameter now allows probabilistic cache degradation. At rel=1.0 (default), absolute costs are optimistic. Exp 011 confirmed that unreliable caching **widens** lcm-subagent's advantage (from 0.5–8.2% to 3–17% over incremental) and eliminates the ~89-cycle crossover. Strategy *rankings* are robust; absolute *cost estimates* from prior experiments should be treated as lower bounds. A realistic production value of rel=0.8–0.9 increases costs 30–100%.
 6. **Reasoning output uncalibrated** (#94): `reasoningOutputSize` defaults to 500 tokens; analysis of 127 Models Agent JSON conversations shows mean=265, and only 47% of turns include thinking. The sim overcharges reasoning ~3-4x. Affects absolute costs (all strategies equally), not rankings.
-7. **Summary convergence ceiling** (#95, addressed): ~~At ratio=10 with 30k interval, summary converges to ~3.3k tokens.~~ Now configurable via `summaryGrowthModel` ('fixed' | 'logarithmic') and `summaryGrowthCoefficient` (default 1000). The 'logarithmic' model applies a growing floor: `coefficient × ln(1 + totalCompressed / 1000)`, preventing convergence in long sessions. Default 'fixed' preserves existing behaviour and prior results. Experiments comparing growth models are pending.
+7. **Summary convergence ceiling** (#95, investigated in Exp 013): ~~At ratio=10 with 30k interval, summary converges to ~3.3k tokens.~~ Now configurable via `summaryGrowthModel` ('fixed' | 'logarithmic') and `summaryGrowthCoefficient` (default 1000). Exp 013 confirmed: logarithmic growth increases costs 1.5–7.6% depending on strategy, with incremental-family strategies hit hardest (7.6% at 200 cycles). Strategy *rankings* are completely stable — lcm-subagent wins at all growth models and coefficients. The 30k interval recommendation is validated and strengthened: under logarithmic growth, 15k becomes 24–28% more expensive for incremental (a double artefact eliminated). `summaryGrowthCoefficient` sensitivity is 10–24% across the 500–2000 range — needs real-world calibration for accurate absolute costs but doesn't affect rankings.
 8. **Tool compression is free in the model** (#103, Exp 012): `toolCompressionEnabled` reduces tool result tokens at ingestion with no processing cost. In practice, ratio≥5 requires LLM summarisation with its own API cost. The sim's 3–5% savings for lcm-subagent at ratio=3+ may be partially offset by compression costs. Ratio=3 is achievable with structured extraction (no LLM), making it the practical recommendation.
 
 ### Cost structure insight (post-Phase 2 review)
@@ -370,7 +418,9 @@ Thinking/assistant ratio: 3.0x (vs implied 3.8x at defaults). Heavy-tailed distr
 - **Realistic cacheReliability value**: What is the actual API cache hit rate in production? Measuring this would ground Exp 011's findings and give accurate absolute cost projections.
 - **Cache reliability × incrementalInterval interaction**: At shorter intervals, more compaction events create more cache invalidation — but each invalidation affects a smaller context. May shift the "30k is safest" recommendation.
 - **Reasoning frequency impact** (#94): Does modelling reasoning on only 47% of turns shift any strategy rankings, or just absolute costs?
-- **Summary growth models** (#95): Does allowing summary size to grow sublinearly over long sessions change the balance between in-context retention vs retrieval?
+- ~~**Summary growth models** (#95): Does allowing summary size to grow sublinearly over long sessions change the balance between in-context retention vs retrieval?~~ **Answered (Exp 013):** No — rankings stable, lcm advantage widens (8.2%→12.1%). 30k interval validated.
+- **summaryGrowthCoefficient calibration**: Real compaction outputs needed to calibrate coefficient (currently untested range 500–2000). Affects absolute costs 10–24% but not rankings.
+- **Growth model × cacheReliability interaction**: Exp 011 showed reliability widens lcm advantage; Exp 013 showed growth model does too. Combined effect may compound.
 - **Cost of tool compression itself**: Exp 012 treats compression as free. In practice, LLM-based summarisation at ratio≥5 has its own API cost. A more realistic model would add a per-result compression cost, which could erode or eliminate the 5% savings at high ratios.
 - **Selective tool compression**: Compressing only large tool results (>500 tokens) while leaving small ones intact might be more practical and still capture most benefit.
 - **Latency modelling**: When wall-clock time matters, compaction frequency trade-offs may flip. Would require engine changes.
@@ -379,11 +429,13 @@ Thinking/assistant ratio: 3.0x (vs implied 3.8x at defaults). Heavy-tailed distr
 
 ---
 
-## Programme Status (2026-04-02)
+## Programme Status (2026-04-03)
 
-**12 experiments complete across 3 phases.** The core research question — which compaction strategy to use for the Models Agent — is answered with high confidence. lcm-subagent wins unconditionally in every tested scenario. No single-parameter perturbation shifts the ranking.
+**13 experiments complete (Phases 1-3 + first Phase 4 experiment).** The core research question — which compaction strategy to use for the Models Agent — is answered with high confidence. lcm-subagent wins unconditionally in every tested scenario, including under more realistic summary growth modelling (Exp 013).
 
 **Phase 4 pivot (Tim direction, 2026-04-02):** The research focus shifts from *which strategy* to *how to implement lcm-subagent*. The guiding question: "What can we simulate to inform the real-world implementation?" This includes implementation variants, optimal configuration, context quality modelling, and summary growth dynamics. See #108 for the full Phase 4 epic.
+
+**Phase 4 progress:** Exp 013 (summary growth dynamics) complete — validated all Phase 1-3 conclusions as robust under logarithmic growth. lcm-subagent advantage amplified from 8.2% to 12.1% at 200 cycles. 30k interval recommendation strengthened.
 
 **Wrap-up backlog (complete before Phase 4 experiments):**
 - ~~**#96 (Update defaults)** — DONE; DEFAULT_CONFIG now uses calibrated Models Agent values~~
@@ -409,3 +461,4 @@ Thinking/assistant ratio: 3.0x (vs implied 3.8x at defaults). Heavy-tailed distr
 | — | #90 | Phase 2 synthesis | done | Cross-experiment conclusions updated; implementation parameters documented |
 | 011 | #98 | Cache reliability sensitivity | done | Rankings stable; lcm advantage widens (3–17% vs 0.5–8.2%); ~89-cycle crossover disappears at rel<=0.9 |
 | 012 | #103 | Tool-result compression sensitivity | done | Secondary lever (3–10% savings); ratio=3 sweet spot; rankings stable; full-compaction worse |
+| 013 | #119 | Summary growth dynamics | done | Rankings stable under logarithmic growth; lcm advantage widens (8.2%→12.1%); 30k interval validated |

--- a/experiments/journal/013-summary-growth-dynamics.md
+++ b/experiments/journal/013-summary-growth-dynamics.md
@@ -1,0 +1,174 @@
+# Exp 013: Summary Growth Dynamics
+
+**Issue:** #119 — Part of #108 (Phase 4)
+**Date:** 2026-04-03
+**Status:** Complete
+
+## Hypothesis
+
+1. **Rankings remain stable** — lcm-subagent should still win because its advantage is structural (smallest average context, best cache stability), not dependent on summary convergence behaviour.
+2. **Absolute costs increase** under logarithmic growth, especially for long sessions (200 cycles).
+3. **lcm-subagent's advantage may widen** — strategies that compact more frequently accumulate more summary text under logarithmic growth.
+4. **Coefficient sensitivity matters** — if the range 500–2000 shifts crossover points or changes rankings, the parameter needs real-world calibration.
+
+## Method
+
+Three sweeps at calibrated baseline (75/380/130/60 token sizes, 10k system prompt, ratio=10, interval=30k, pRetrieveMax=0.2).
+
+### Sweep 1: Fixed vs Logarithmic across all strategies
+- `summaryGrowthModel` ['fixed', 'logarithmic'] × `selectedStrategy` [all 6] × `toolCallCycles` [100, 150, 200]
+- `summaryGrowthCoefficient` = 1000 (default)
+- 36 runs
+
+### Sweep 2: Coefficient sensitivity
+- `summaryGrowthCoefficient` [500, 1000, 1500, 2000] × `selectedStrategy` ['lcm-subagent', 'incremental'] × `toolCallCycles` [100, 150, 200]
+- `summaryGrowthModel` = 'logarithmic'
+- 24 runs
+
+### Sweep 3: Growth model × incrementalInterval interaction
+- `summaryGrowthModel` ['fixed', 'logarithmic'] × `incrementalInterval` [15000, 30000, 50000] × `selectedStrategy` ['lcm-subagent', 'incremental'] × `toolCallCycles` [150, 200]
+- 24 runs
+
+All configs and results in `experiments/data/013/`.
+
+## Results
+
+### Sweep 1: Fixed vs Logarithmic — Cost Impact
+
+| Strategy | Cycles | Fixed | Logarithmic | % Change |
+|---|---|---|---|---|
+| full-compaction | 100 | $8.61 | $8.61 | 0.00% |
+| full-compaction | 150 | $16.83 | $16.83 | 0.00% |
+| full-compaction | 200 | $20.71 | $20.71 | 0.00% |
+| incremental | 100 | $5.12 | $5.25 | +2.50% |
+| incremental | 150 | $8.13 | $8.53 | +4.96% |
+| incremental | 200 | $11.43 | $12.30 | +7.60% |
+| lossless-append | 100 | $5.30 | $5.43 | +2.42% |
+| lossless-append | 150 | $8.47 | $8.87 | +4.76% |
+| lossless-append | 200 | $11.92 | $12.79 | +7.29% |
+| lossless-hierarchical | 100 | $5.25 | $5.33 | +1.48% |
+| lossless-hierarchical | 150 | $8.26 | $8.45 | +2.29% |
+| lossless-hierarchical | 200 | $11.34 | $11.67 | +2.89% |
+| lossless-tool-results | 100 | $5.17 | $5.26 | +1.81% |
+| lossless-tool-results | 150 | $8.23 | $8.50 | +3.33% |
+| lossless-tool-results | 200 | $11.63 | $12.21 | +4.96% |
+| lcm-subagent | 100 | $5.09 | $5.17 | +1.51% |
+| lcm-subagent | 150 | $7.79 | $7.97 | +2.39% |
+| lcm-subagent | 200 | $10.49 | $10.81 | +3.05% |
+
+**full-compaction is unaffected** — it either doesn't compact (100 cycles) or compacts once (150/200), so the growth model has no effect on summary accumulation.
+
+**Strategies that compact frequently are hit hardest**: incremental and lossless-append see 7–8% cost increases at 200 cycles. lcm-subagent and lossless-hierarchical (both full-replacement) are more resilient at 2.9–3.1%.
+
+### Sweep 1: Rankings at 200 Cycles
+
+| Rank | Fixed | Cost | Logarithmic | Cost |
+|---|---|---|---|---|
+| 1 | lcm-subagent | $10.49 | lcm-subagent | $10.81 |
+| 2 | lossless-hierarchical | $11.34 | lossless-hierarchical | $11.67 |
+| 3 | incremental | $11.43 | lossless-tool-results | $12.21 |
+| 4 | lossless-tool-results | $11.63 | incremental | $12.30 |
+| 5 | lossless-append | $11.92 | lossless-append | $12.79 |
+| 6 | full-compaction | $20.71 | full-compaction | $20.71 |
+
+**Top-2 (lcm-subagent, lossless-hierarchical) and bottom (full-compaction) are stable.** Incremental and lossless-tool-results swap #3/#4 — incremental's frequent compaction produces larger accumulated summaries under logarithmic growth.
+
+### Sweep 1: lcm-subagent Advantage Over Incremental
+
+| Cycles | Fixed Advantage | Logarithmic Advantage |
+|---|---|---|
+| 100 | 0.54% | 1.50% |
+| 150 | 4.22% | 6.57% |
+| 200 | 8.20% | 12.07% |
+
+**Hypothesis 3 confirmed: lcm-subagent's advantage widens significantly** — from 8.2% to 12.1% at 200 cycles. lcm-subagent's full-replacement approach keeps context tighter as summaries grow.
+
+### Sweep 2: Coefficient Sensitivity
+
+| Coefficient | lcm (100) | inc (100) | lcm adv | lcm (150) | inc (150) | lcm adv | lcm (200) | inc (200) | lcm adv |
+|---|---|---|---|---|---|---|---|---|---|
+| 500 | $5.09 | $5.12 | 0.5% | $7.79 | $8.13 | 4.2% | $10.49 | $11.43 | 8.2% |
+| 1000 | $5.17 | $5.25 | 1.5% | $7.97 | $8.53 | 6.6% | $10.81 | $12.30 | 12.1% |
+| 1500 | $5.38 | $5.55 | 3.1% | $8.36 | $9.31 | 10.2% | $11.39 | $13.77 | 17.3% |
+| 2000 | $5.58 | $5.86 | 4.7% | $8.74 | $10.08 | 13.3% | $11.96 | $13.81 | 13.4% |
+
+**Cost swing across coefficient range (500→2000):**
+
+| Strategy | 100 cycles | 150 cycles | 200 cycles |
+|---|---|---|---|
+| lcm-subagent | 9.6% | 12.3% | 14.0% |
+| incremental | 14.4% | 24.0% | 20.8% |
+
+**Coefficient sensitivity is significant** — the 500→2000 range produces a 10–14% cost swing for lcm-subagent and 14–24% for incremental. The parameter needs real-world calibration for accurate absolute cost estimates.
+
+Note: at coeff=500 the results match the fixed model exactly (the logarithmic floor is too small to exceed the fixed summary size at this coefficient). At coeff=2000, incremental at 200 cycles shows a ceiling effect ($13.77→$13.81 between 1500 and 2000) — more frequent compaction kicks in to prevent runaway context growth.
+
+### Sweep 3: Growth Model × Interval Interaction
+
+**% change from fixed to logarithmic:**
+
+| Strategy | Interval | 150 cycles | 200 cycles |
+|---|---|---|---|
+| incremental | 15,000 | +27.8% | +23.6% |
+| incremental | 30,000 | +5.0% | +7.6% |
+| incremental | 50,000 | 0.0% | +0.1% |
+| lcm-subagent | 15,000 | +9.9% | +11.3% |
+| lcm-subagent | 30,000 | +2.4% | +3.1% |
+| lcm-subagent | 50,000 | 0.0% | 0.0% |
+
+**Critical finding: the growth model interacts strongly with incrementalInterval for incremental, but not for lcm-subagent.**
+
+| Strategy | Fixed optimal | Logarithmic optimal | Changed? |
+|---|---|---|---|
+| incremental (150 cycles) | 15,000 | 30,000 | **YES** |
+| incremental (200 cycles) | 15,000 | 30,000 | **YES** |
+| lcm-subagent (150 cycles) | 15,000 | 15,000 | No |
+| lcm-subagent (200 cycles) | 15,000 | 15,000 | No |
+
+Under fixed growth, incremental's cheapest interval is 15,000 — but we already know this is a modelling artefact (no quality penalty for over-compaction). Under logarithmic growth, 15,000 becomes the **most expensive** interval for incremental (+28% cost penalty), because frequent compaction accumulates large growing summaries. The optimal shifts to 30,000.
+
+This validates the Exp 008 recommendation: **30k interval is defensible** and is now *required* under more realistic summary growth modelling. The 15k "cheaper" result from Exp 008 was indeed a double artefact — no quality penalty AND fixed summary convergence.
+
+## Analysis
+
+### Hypothesis evaluation
+
+1. **Rankings stable** ✅ — lcm-subagent is #1 at all growth models, cycle lengths, coefficients, and intervals tested. No parameter combination flips the ranking. Minor reordering in the #3/#4 positions (incremental ↔ lossless-tool-results) does not affect the strategy recommendation.
+
+2. **Absolute costs increase** ✅ — 1.5–7.6% increase at default coefficient (1000), scaling with compaction frequency and session length. Not enough to invalidate prior cost estimates but worth noting.
+
+3. **lcm-subagent advantage widens** ✅ — from 8.2% to 12.1% at 200 cycles (default coefficient). At coeff=1500, the advantage reaches 17.3%. The mechanism is clear: full-replacement strategies keep tighter context, so growing summaries penalise incremental-family strategies more.
+
+4. **Coefficient sensitivity matters** ✅ — 10–24% cost swing across the 500–2000 range. This parameter needs calibration from real compaction outputs, but it doesn't affect strategy *rankings*.
+
+### Why lcm-subagent is more resilient
+
+The structural advantage identified in Exp 009 (full-replacement produces a cache-stable prefix with smaller average context) is amplified under logarithmic growth. Incremental strategies accumulate summaries across compactions — when each summary grows sublinearly, the accumulation grows faster than under fixed convergence. lcm-subagent replaces the entire summary each time, so its context size is governed by a single (growing) summary rather than accumulated fragments.
+
+### The 30k interval recommendation is now stronger
+
+Under fixed growth, both 15k and 30k are defensible for incremental (15k was "cheaper" but a known artefact). Under logarithmic growth, 15k is actively harmful — it increases incremental's cost by 24–28%. The 30k default is the correct choice under both models. For lcm-subagent, the interval matters less (15k stays optimal under both models), but 30k remains the practical recommendation to avoid over-compaction quality risks.
+
+### Limitations
+
+- The logarithmic growth formula `coefficient × ln(1 + totalCompressed / 1000)` is a parameterised assumption, not calibrated against real compaction outputs. Real summary growth patterns may differ.
+- At coeff=500, logarithmic growth has no effect (floor never exceeds fixed summary size) — this is a lower bound on where the model diverges.
+- The growth model only affects strategies that compact. full-compaction is unaffected because it either never fires or fires once.
+
+## Conclusions
+
+1. **Phase 1-3 conclusions are robust under logarithmic summary growth.** Strategy rankings are completely stable. lcm-subagent wins unconditionally.
+
+2. **lcm-subagent's advantage is amplified** under more realistic summary modelling — from 8.2% to 12.1% over incremental at 200 cycles. The structural advantage (smallest context, full-replacement) also confers resilience to summary growth dynamics.
+
+3. **The 30k incrementalInterval recommendation is validated and strengthened.** Under logarithmic growth, 15k becomes actively harmful for incremental (+28% cost). The "15k is cheapest" result was a double artefact of the fixed-growth model.
+
+4. **Coefficient sensitivity is significant but only affects absolute costs, not rankings.** The parameter needs real-world calibration for production cost estimates.
+
+5. **No Phase 1-3 conclusions need revision.** This experiment validates the prior evidence base as robust under more realistic modelling.
+
+## Next Questions
+
+- What is the actual summary growth pattern from real compaction outputs? Calibrating `summaryGrowthCoefficient` would improve absolute cost accuracy.
+- Does the coefficient interact with `cacheReliability`? (Exp 011 showed reliability widens lcm advantage — does growth model compound this effect?)
+- At very long sessions (>200 cycles), does logarithmic growth eventually cause context overflow or force additional compactions?


### PR DESCRIPTION
## Summary

- Ran 3 sweeps (84 total simulation runs) testing logarithmic vs fixed summary growth across all strategies, coefficient sensitivity, and interval interaction
- **Strategy rankings completely stable** — lcm-subagent wins at all growth models, coefficients, and intervals tested
- **lcm-subagent advantage amplified** from 8.2% to 12.1% over incremental at 200 cycles under logarithmic growth
- **30k interval recommendation validated and strengthened** — under logarithmic growth, 15k becomes 24-28% more expensive for incremental (double artefact eliminated)
- **Phase 1-3 conclusions are fully robust** under more realistic summary growth modelling

Closes #119

## Test plan

- [x] All three sweeps completed successfully with valid output
- [x] Results consistent with prior experiment baselines (fixed-growth numbers match Exp 003/008)
- [x] FINDINGS.md updated with new section, updated limitation #7, updated experiment index and programme status
- [x] Journal entry complete with hypothesis evaluation, quantitative results, and limitations

🤖 Generated with [Claude Code](https://claude.com/claude-code)