### PR TITLE
Add Exp 014: contextWindow × compactionThreshold sensitivity

### DIFF
--- a/experiments/FINDINGS.md
+++ b/experiments/FINDINGS.md
@@ -347,11 +347,53 @@ Under logarithmic growth, incremental's optimal interval shifts from 15k to 30k 
 
 ---
 
+## contextWindow × compactionThreshold Sensitivity (Exp 014)
+
+Sweep over `contextWindow` [30k–500k] and `compactionThreshold` [0.50–0.95] for lcm-subagent, plus cross-strategy validation at [64k, 128k, 200k], calibrated baseline.
+
+### lcm-subagent: contextWindow has zero effect at ≥50k
+
+| contextWindow | 100c Cost | 200c Cost | Peak Context | Compactions (200c) |
+|---|---|---|---|---|
+| 30,000 | $4.29 | $8.69 | 25,440 | 15 |
+| 40,000 | $4.73 | $9.62 | 33,990 | 9 |
+| 50,000 | $5.09 | $10.40 | 42,426 | 7 |
+| **≥64,000** | **$5.09** | **$10.49** | **43,352** | **7** |
+
+lcm-subagent's peak context is 43,352 tokens. The compaction threshold at 64k × 0.85 = 54,400 is never reached. The incrementalInterval (30k) is the sole compaction driver.
+
+Below ~50k, the window threshold fires, forcing more compaction and lower costs — but this is the same modelling artefact as Exp 008 (no quality/latency penalty for compaction).
+
+### compactionThreshold: irrelevant at standard windows
+
+At 200k window, all thresholds [0.70–0.95] produce identical costs. At 40k window, threshold has effect (23% cost spread, 0.50–0.95) — same artefact.
+
+### Cross-strategy window sensitivity (200 cycles)
+
+| Strategy | 64k | 128k | 200k | Sensitivity |
+|---|---|---|---|---|
+| **lcm-subagent** | **$10.49** | **$10.49** | **$10.49** | None |
+| lossless-hierarchical | $11.34 | $11.34 | $11.34 | None |
+| full-compaction | **$11.31** | $16.26 | $20.71 | **−45%** |
+| incremental | $11.36 | $11.43 | $11.43 | Marginal |
+| lossless-tool-results | $11.56 | $11.63 | $11.63 | Marginal |
+| lossless-append | $11.85 | $11.92 | $11.92 | Marginal |
+
+**full-compaction is massively window-sensitive** — at 64k it compacts 5× instead of once, reducing cost 45%. At 64k, all strategies converge to a narrow $10.49–$11.85 range (13% spread vs 97% at 200k). But lcm-subagent remains #1 at every window.
+
+**Key findings:**
+1. **contextWindow is a non-decision for lcm-subagent** — use whatever the API provides. The incrementalInterval is the binding compaction constraint.
+2. **compactionThreshold is similarly irrelevant** — context never approaches the threshold at standard windows.
+3. **full-compaction's poor performance is partly a window artefact** — at 64k it approaches parity with other strategies ($11.31 vs $11.43 incremental). But lcm-subagent still wins.
+4. **Strategy rankings stable** across all window sizes and thresholds.
+
+---
+
 ## Cross-Experiment Conclusions
 
 ### Strategy recommendation for Models Agent
 
-**Use `lcm-subagent` unconditionally.** Across 13 experiments spanning Phase 1 (baselines and parameter sweeps), Phase 2 (retrieval stress tests), Phase 3 (cache and ingestion), and Phase 4 (summary growth dynamics), lcm-subagent is the cheapest strategy in every realistic scenario.
+**Use `lcm-subagent` unconditionally.** Across 14 experiments spanning Phase 1 (baselines and parameter sweeps), Phase 2 (retrieval stress tests), Phase 3 (cache and ingestion), and Phase 4 (deployment optimisation), lcm-subagent is the cheapest strategy in every realistic scenario.
 
 | Session length | Strategy | Cost advantage over next-best | Confidence |
 |---|---|---|---|
@@ -367,6 +409,8 @@ Under logarithmic growth, incremental's optimal interval shifts from 15k to 30k 
 | Parameter | Recommended value | Notes |
 |---|---|---|
 | `selectedStrategy` | `lcm-subagent` | Use unconditionally |
+| `contextWindow` | API default (128k–200k) | Non-decision: lcm-subagent's peak context (43k) never reaches window threshold. incrementalInterval drives compaction (Exp 014) |
+| `compactionThreshold` | 0.85 (default) | Non-decision: irrelevant for lcm-subagent at any standard window (Exp 014) |
 | `compressionRatio` | 10 (default) | Higher appears cheaper in model but is a modelling artefact; 10× is practically achievable |
 | `incrementalInterval` | 30,000 (default) | 15k appears cheapest but is a modelling artefact; 30k avoids over-summarisation risk |
 | `pRetrieveMax` | 0.2 (default) | Well within safe zone; recommendation flips only at 0.27–0.77 depending on session length |
@@ -431,11 +475,13 @@ Thinking/assistant ratio: 3.0x (vs implied 3.8x at defaults). Heavy-tailed distr
 
 ## Programme Status (2026-04-03)
 
-**13 experiments complete (Phases 1-3 + first Phase 4 experiment).** The core research question — which compaction strategy to use for the Models Agent — is answered with high confidence. lcm-subagent wins unconditionally in every tested scenario, including under more realistic summary growth modelling (Exp 013).
+**14 experiments complete (Phases 1-3 + two Phase 4 experiments).** The core research question — which compaction strategy to use for the Models Agent — is answered with high confidence. lcm-subagent wins unconditionally in every tested scenario.
 
 **Phase 4 pivot (Tim direction, 2026-04-02):** The research focus shifts from *which strategy* to *how to implement lcm-subagent*. The guiding question: "What can we simulate to inform the real-world implementation?" This includes implementation variants, optimal configuration, context quality modelling, and summary growth dynamics. See #108 for the full Phase 4 epic.
 
-**Phase 4 progress:** Exp 013 (summary growth dynamics) complete — validated all Phase 1-3 conclusions as robust under logarithmic growth. lcm-subagent advantage amplified from 8.2% to 12.1% at 200 cycles. 30k interval recommendation strengthened.
+**Phase 4 progress:**
+- Exp 013 (summary growth dynamics) — validated all Phase 1-3 conclusions as robust under logarithmic growth. lcm-subagent advantage amplified from 8.2% to 12.1% at 200 cycles.
+- Exp 014 (contextWindow × compactionThreshold) — both parameters are non-decisions for lcm-subagent. incrementalInterval is the sole compaction driver. Full-compaction's poor performance is partly a window artefact.
 
 **Wrap-up backlog (complete before Phase 4 experiments):**
 - ~~**#96 (Update defaults)** — DONE; DEFAULT_CONFIG now uses calibrated Models Agent values~~
@@ -462,3 +508,4 @@ Thinking/assistant ratio: 3.0x (vs implied 3.8x at defaults). Heavy-tailed distr
 | 011 | #98 | Cache reliability sensitivity | done | Rankings stable; lcm advantage widens (3–17% vs 0.5–8.2%); ~89-cycle crossover disappears at rel<=0.9 |
 | 012 | #103 | Tool-result compression sensitivity | done | Secondary lever (3–10% savings); ratio=3 sweet spot; rankings stable; full-compaction worse |
 | 013 | #119 | Summary growth dynamics | done | Rankings stable under logarithmic growth; lcm advantage widens (8.2%→12.1%); 30k interval validated |
+| 014 | #121 | contextWindow × compactionThreshold sensitivity | done | contextWindow and threshold are non-decisions for lcm-subagent; incrementalInterval drives compaction; full-compaction penalty is partly a window artefact |

--- a/experiments/journal/014-context-window-threshold.md
+++ b/experiments/journal/014-context-window-threshold.md
@@ -1,0 +1,136 @@
+# Experiment 014: contextWindow × compactionThreshold Sensitivity
+
+**Issue:** #121
+**Date:** 2026-04-03
+**Phase:** 4 (Optimal configuration for lcm-subagent deployment)
+
+## Hypothesis
+
+Smaller context windows will reduce lcm-subagent cost by keeping average context smaller (reducing the dominant cached-input cost component). Below some threshold, increased compaction frequency will erode cache stability, creating a cost minimum at ~100–128k rather than the default 200k.
+
+## Method
+
+Five sweeps were run, all using calibrated Models Agent parameters:
+
+**Sweep 1a** — contextWindow [64k, 100k, 128k, 200k, 500k] × toolCallCycles [100, 150, 200], lcm-subagent only.
+
+**Sweep 1b** — contextWindow [30k, 35k, 40k, 45k, 50k, 64k] × toolCallCycles [100, 150, 200], lcm-subagent only. Follow-up after Sweep 1a showed no variation — needed smaller windows.
+
+**Sweep 2a** — compactionThreshold [0.70–0.95] × toolCallCycles [100, 150, 200] at 200k window, lcm-subagent.
+
+**Sweep 2b** — compactionThreshold [0.50–0.95] × toolCallCycles [100, 150, 200] at 40k window, lcm-subagent.
+
+**Sweep 3** — All 6 strategies × contextWindow [64k, 128k, 200k] × toolCallCycles [100, 150, 200].
+
+Configs and raw output: `experiments/data/014/`.
+
+## Results
+
+### Sweep 1: contextWindow sensitivity (lcm-subagent)
+
+| contextWindow | 100 cycles | 150 cycles | 200 cycles | Peak Context | Compactions (200c) |
+|---|---|---|---|---|---|
+| 30,000 | $4.29 | $6.50 | $8.69 | 25,440 | 15 |
+| 35,000 | $4.51 | $6.88 | $9.19 | 29,650 | 12 |
+| 40,000 | $4.73 | $7.17 | $9.62 | 33,990 | 9 |
+| 45,000 | $4.98 | $7.49 | $10.03 | 38,044 | 8 |
+| 50,000 | $5.09 | $7.74 | $10.40 | 42,426 | 7 |
+| **≥64,000** | **$5.09** | **$7.79** | **$10.49** | **43,352** | **7** |
+
+**All windows ≥64k produce identical results.** lcm-subagent's peak context (43,352) never reaches the compaction threshold at 64k (64k × 0.85 = 54,400). The incrementalInterval (30k) is the sole compaction driver.
+
+Below ~50k, the window threshold fires before incrementalInterval, forcing more frequent compaction:
+- 30k window: 17% cheaper ($8.69 vs $10.49 at 200 cycles), but 15 compactions (vs 7)
+- This is the same **modelling artefact** identified in Exp 008: the model has no quality/latency penalty for compaction, so more compaction is always cheaper
+
+### Sweep 2: compactionThreshold sensitivity
+
+**At 200k window:** Completely flat. All thresholds [0.70–0.95] produce identical costs. Context never approaches the threshold.
+
+**At 40k window:** Threshold has a clear effect:
+
+| Threshold | 100c Cost | 200c Cost | Peak Context | Compactions (200c) |
+|---|---|---|---|---|
+| 0.50 | $4.01 | $8.12 | 19,955 | 23 |
+| 0.70 | $4.40 | $8.95 | 27,711 | 13 |
+| 0.85 | $4.73 | $9.62 | 33,990 | 9 |
+| 0.95 | $4.96 | $10.00 | 37,988 | 8 |
+
+Lower thresholds = more compaction = cheaper, with 23% cost spread across the range. Same modelling artefact applies: the model always prefers more compaction.
+
+### Sweep 3: Cross-strategy contextWindow sensitivity (key finding)
+
+**200 cycles:**
+
+| Strategy | 64k | 128k | 200k | Window-sensitive? |
+|---|---|---|---|---|
+| **lcm-subagent** | **$10.49** | **$10.49** | **$10.49** | No |
+| lossless-hierarchical | $11.34 | $11.34 | $11.34 | No |
+| full-compaction | **$11.31** | $16.26 | $20.71 | **YES — 45% swing** |
+| incremental | $11.36 | $11.43 | $11.43 | Marginal |
+| lossless-tool-results | $11.56 | $11.63 | $11.63 | Marginal |
+| lossless-append | $11.85 | $11.92 | $11.92 | Marginal |
+
+**Full-compaction is massively window-sensitive.** At 64k, it compacts 5× instead of once, reducing cost from $20.71 to $11.31 (−45%). At 64k, full-compaction ($11.31) is comparable to incremental ($11.36) — the penalty nearly disappears.
+
+**lcm-subagent and lossless-hierarchical are completely window-insensitive** — both use full-replacement compaction driven by incrementalInterval, keeping peak context at 43,352 regardless of window.
+
+**Rankings at 64k/200 cycles:** All strategies converge to $10.49–$11.85 (13% spread vs 97% spread at 200k). lcm-subagent is still #1 at every window.
+
+**150 cycles:**
+
+| Strategy | 64k | 128k | 200k |
+|---|---|---|---|
+| **lcm-subagent** | **$7.79** | **$7.79** | **$7.79** |
+| incremental | $8.13 | $8.13 | $8.13 |
+| lossless-tool-results | $8.23 | $8.23 | $8.23 |
+| lossless-hierarchical | $8.26 | $8.26 | $8.26 |
+| lossless-append | $8.47 | $8.47 | $8.47 |
+| full-compaction | **$8.52** | **$11.91** | **$16.83** |
+
+At 150 cycles, full-compaction's penalty shrinks from 116% (200k) to 9% (64k).
+
+## Analysis
+
+### Why contextWindow doesn't matter for lcm-subagent
+
+lcm-subagent uses full-replacement compaction triggered by incrementalInterval (30k new tokens). At the calibrated baseline, context grows at ~455 tokens/cycle (75 tool call + 380 tool result). After compaction, it resets to system prompt (10k) + summary (~3.3k) ≈ 13.3k. It takes ~37 cycles to accumulate 30k new tokens, at which point context is ~43k — well below any window threshold ≥54k.
+
+The contextWindow parameter is irrelevant for lcm-subagent. The incrementalInterval is the binding constraint.
+
+### Why full-compaction is window-sensitive
+
+Full-compaction has no incrementalInterval. It only compacts when context hits `contextWindow × compactionThreshold`. At 200k/0.85 (threshold 170k), context must grow to 170k before compacting — which takes ~350 cycles. In a 200-cycle session, it fires at most once, running most steps at high context (average ~80k).
+
+At 64k/0.85 (threshold 54.4k), compaction fires every ~97 cycles, keeping average context much smaller. This eliminates full-compaction's primary weakness.
+
+### Modelling artefact warning
+
+The model shows that smaller windows and lower thresholds are always cheaper for lcm-subagent. This is the same artefact identified in Exp 008: the simulation has no quality penalty for compaction. In practice:
+- 15 compactions per 200-cycle session (30k window) means compacting every ~13 cycles — aggressive enough to risk severe information loss
+- 23 compactions (40k/0.50 threshold) is unrealistic for quality conversation maintenance
+- The "cheaper at small windows" finding is a modelling artefact, not a deployment recommendation
+
+### Real deployment insight
+
+For lcm-subagent, **contextWindow doesn't matter** at any value ≥ 50k. Set it to whatever the API supports (typically 128k or 200k). The incrementalInterval is the only knob that matters.
+
+For full-compaction, contextWindow matters enormously — but this doesn't change the recommendation since lcm-subagent is still cheaper at every window.
+
+## Conclusions
+
+1. **Hypothesis rejected.** contextWindow has zero effect on lcm-subagent cost at ≥50k (not the expected convex minimum). The incrementalInterval (30k) is the sole compaction driver, keeping peak context at 43k — far below any practical window threshold.
+
+2. **compactionThreshold is similarly irrelevant** for lcm-subagent at standard windows. At 200k window, the entire 0.70–0.95 range produces identical results.
+
+3. **Full-compaction's poor performance is partly a window artefact.** At 64k, its cost drops 45% and approaches parity with incremental strategies. But lcm-subagent still wins at every window size.
+
+4. **Strategy rankings are stable** across all contextWindow values. lcm-subagent is #1 at 64k, 128k, and 200k.
+
+5. **Implementation recommendation: contextWindow and compactionThreshold are non-decisions** for Models Agent deployment with lcm-subagent. Use whatever the API provides (128k or 200k). The strategy's compaction is driven entirely by incrementalInterval, which was already validated at 30k (Exp 008).
+
+## Next questions
+
+- Does the window insensitivity hold under logarithmic summary growth? (probably yes, since Exp 013 showed peak context only rises ~3% under logarithmic growth)
+- At what incrementalInterval does the window threshold start to matter for lcm-subagent? (would need interval > ~43k, above the recommended 30k)
+- Would a "hybrid trigger" — compact at min(incrementalInterval, windowThreshold) — be worth modelling? (probably not, given both are already redundant)


### PR DESCRIPTION
Closes #121

## Summary

- contextWindow and compactionThreshold are **non-decisions** for lcm-subagent — incrementalInterval is the sole compaction driver
- lcm-subagent peak context (43k) never reaches window threshold at any standard window (≥50k)
- full-compaction's poor performance is partly a window artefact: at 64k its cost drops 45%
- Strategy rankings stable across all window sizes and thresholds

## Sweeps run

1. **contextWindow [30k–500k]** × cycles [100, 150, 200] — lcm-subagent only → flat at ≥50k
2. **compactionThreshold [0.50–0.95]** at 200k and 40k windows → irrelevant at standard windows
3. **All 6 strategies** × contextWindow [64k, 128k, 200k] → rankings stable; full-compaction window-sensitive

## FINDINGS.md updates

- New Exp 014 section with full results
- Added contextWindow and compactionThreshold to implementation parameters table (both marked as non-decisions)
- Updated programme status and experiment index

🤖 Generated with [Claude Code](https://claude.com/claude-code)